### PR TITLE
fix: gracefully handle invalid UDP packet

### DIFF
--- a/boltconn/src/network/packet/ip.rs
+++ b/boltconn/src/network/packet/ip.rs
@@ -125,6 +125,13 @@ impl IPPkt {
         }
     }
 
+    pub fn ip_header_len(&self) -> usize {
+        match self {
+            IPPkt::V4(_) => Ipv4Packet::new_unchecked(self.packet_data()).header_len() as usize,
+            IPPkt::V6(_) => Ipv6Packet::new_unchecked(self.packet_data()).header_len(),
+        }
+    }
+
     pub fn pkt_total_len(&self) -> usize {
         match self {
             IPPkt::V4(_) => Ipv4Packet::new_unchecked(self.packet_data()).total_len() as usize,

--- a/boltconn/src/network/tun_device.rs
+++ b/boltconn/src/network/tun_device.rs
@@ -254,6 +254,10 @@ impl TunDevice {
                 }
             }
             IpProtocol::Udp => {
+                if pkt.pkt_total_len() < pkt.ip_header_len() + 8 {
+                    // drop invalid UDP packet
+                    return;
+                }
                 let pkt = UdpPkt::new(pkt);
                 if pkt.dst_port() == 53 && dst == self.fake_dns_addr {
                     // fake ip


### PR DESCRIPTION
Avoid panic when processing some UDP packets which not follow RFC 768, e.g. tinc.