### PR TITLE
Refactor: internal error type

### DIFF
--- a/boltconn/src/adapter/socks5.rs
+++ b/boltconn/src/adapter/socks5.rs
@@ -6,6 +6,7 @@ use crate::common::{as_io_err, io_err, StreamOutboundTrait};
 use crate::config::AuthData;
 use crate::network::dns::Dns;
 use crate::network::egress::Egress;
+use crate::proxy::error::TransportError;
 use crate::proxy::{ConnAbortHandle, NetworkAddr};
 use crate::transport::UdpSocketAdapter;
 use async_trait::async_trait;
@@ -13,7 +14,6 @@ use fast_socks5::client::Socks5Stream;
 use fast_socks5::util::target_addr::TargetAddr;
 use fast_socks5::{AuthenticationMethod, Socks5Command};
 use std::io;
-use std::io::Result;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -57,7 +57,7 @@ impl Socks5Outbound {
         }
     }
 
-    async fn connect_proxy<S>(&self, outbound: S) -> Result<Socks5Stream<S>>
+    async fn connect_proxy<S>(&self, outbound: S) -> io::Result<Socks5Stream<S>>
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
@@ -73,7 +73,7 @@ impl Socks5Outbound {
         inbound: Connector,
         outbound: S,
         abort_handle: ConnAbortHandle,
-    ) -> Result<()>
+    ) -> io::Result<()>
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
@@ -93,7 +93,7 @@ impl Socks5Outbound {
         outbound: S,
         abort_handle: ConnAbortHandle,
         tunnel_only: bool,
-    ) -> Result<()>
+    ) -> io::Result<()>
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
@@ -207,7 +207,7 @@ struct Socks5UdpAdapter(Arc<UdpSocket>);
 
 #[async_trait]
 impl UdpSocketAdapter for Socks5UdpAdapter {
-    async fn send_to(&self, data: &[u8], addr: NetworkAddr) -> anyhow::Result<()> {
+    async fn send_to(&self, data: &[u8], addr: NetworkAddr) -> Result<(), TransportError> {
         let mut buf = match addr {
             NetworkAddr::Raw(s) => fast_socks5::new_udp_header(s)?,
             NetworkAddr::DomainName { domain_name, port } => {
@@ -219,12 +219,12 @@ impl UdpSocketAdapter for Socks5UdpAdapter {
         Ok(())
     }
 
-    async fn recv_from(&self, data: &mut [u8]) -> anyhow::Result<(usize, NetworkAddr)> {
+    async fn recv_from(&self, data: &mut [u8]) -> Result<(usize, NetworkAddr), TransportError> {
         let mut buf = [0u8; 0x10000];
         let (size, _) = self.0.recv_from(&mut buf).await?;
         let (frag, target_addr, raw_data) = fast_socks5::parse_udp_request(&buf[..size]).await?;
         if frag != 0 {
-            return Err(anyhow::anyhow!("Unsupported frag value."));
+            return Err(TransportError::UnsupportedSocks5UdpFragment);
         }
         data[..raw_data.len()].copy_from_slice(raw_data);
         Ok((raw_data.len(), target_addr.into()))

--- a/boltconn/src/adapter/socks5.rs
+++ b/boltconn/src/adapter/socks5.rs
@@ -224,7 +224,7 @@ impl UdpSocketAdapter for Socks5UdpAdapter {
         let (size, _) = self.0.recv_from(&mut buf).await?;
         let (frag, target_addr, raw_data) = fast_socks5::parse_udp_request(&buf[..size]).await?;
         if frag != 0 {
-            return Err(TransportError::UnsupportedSocks5UdpFragment);
+            return Err(TransportError::Socks5Extra("UDP fragment not supported"));
         }
         data[..raw_data.len()].copy_from_slice(raw_data);
         Ok((raw_data.len(), target_addr.into()))

--- a/boltconn/src/adapter/trojan.rs
+++ b/boltconn/src/adapter/trojan.rs
@@ -6,6 +6,7 @@ use crate::common::async_ws_stream::AsyncWsStream;
 use crate::common::{as_io_err, io_err, StreamOutboundTrait};
 use crate::network::dns::Dns;
 use crate::network::egress::Egress;
+use crate::proxy::error::TransportError;
 use crate::proxy::{ConnAbortHandle, NetworkAddr};
 use crate::transport::trojan::{
     encapsule_udp_packet, make_tls_config, TrojanAddr, TrojanCmd, TrojanConfig, TrojanReqInner,
@@ -272,12 +273,12 @@ impl<S> UdpSocketAdapter for TrojanUdpAdapter<S>
 where
     S: AsyncRead + AsyncWrite + Send,
 {
-    async fn send_to(&self, data: &[u8], addr: NetworkAddr) -> anyhow::Result<()> {
+    async fn send_to(&self, data: &[u8], addr: NetworkAddr) -> Result<(), TransportError> {
         self.socket.send_to(data, addr).await?;
         Ok(())
     }
 
-    async fn recv_from(&self, data: &mut [u8]) -> anyhow::Result<(usize, NetworkAddr)> {
+    async fn recv_from(&self, data: &mut [u8]) -> Result<(usize, NetworkAddr), TransportError> {
         let (size, addr) = self.socket.recv_from(data).await?;
         Ok((size, addr))
     }

--- a/boltconn/src/adapter/trojan.rs
+++ b/boltconn/src/adapter/trojan.rs
@@ -13,7 +13,6 @@ use crate::transport::trojan::{
     TrojanRequest, TrojanUdpSocket,
 };
 use crate::transport::UdpSocketAdapter;
-use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
 use http::{StatusCode, Uri};
@@ -155,15 +154,18 @@ impl TrojanOutbound {
         &self,
         stream: S,
         path: &str,
-    ) -> Result<AsyncWsStream<S>> {
+    ) -> Result<AsyncWsStream<S>, TransportError> {
         let uri = Uri::builder()
             .scheme("wss")
             .authority(self.config.sni.as_str())
             .path_and_query(path)
-            .build()?;
-        let (stream, resp) = client_async(uri, stream).await?;
+            .build()
+            .map_err(|_| TransportError::Trojan("Invalid wss uri"))?;
+        let (stream, resp) = client_async(uri, stream)
+            .await
+            .map_err(|_| TransportError::Trojan("Websocket client_sync failed"))?;
         if resp.status() != StatusCode::SWITCHING_PROTOCOLS {
-            return Err(anyhow!("Bad status:{}", resp.status()));
+            return Err(TransportError::Trojan("Websocket upgrade failed"));
         }
         Ok(AsyncWsStream::new(stream))
     }

--- a/boltconn/src/adapter/udp_over_tcp.rs
+++ b/boltconn/src/adapter/udp_over_tcp.rs
@@ -1,3 +1,4 @@
+use crate::proxy::error::TransportError;
 use crate::proxy::NetworkAddr;
 use crate::transport::UdpSocketAdapter;
 use async_trait::async_trait;
@@ -27,21 +28,23 @@ impl UdpOverTcpAdapter {
 
 #[async_trait]
 impl UdpSocketAdapter for UdpOverTcpAdapter {
-    async fn send_to(&self, data: &[u8], _addr: NetworkAddr) -> anyhow::Result<()> {
-        let len = u16::try_from(data.len())?.to_be_bytes();
+    async fn send_to(&self, data: &[u8], _addr: NetworkAddr) -> Result<(), TransportError> {
+        let len = u16::try_from(data.len())
+            .map_err(|_| TransportError::Internal("UDP-over-TCP exceeded u16::size"))?
+            .to_be_bytes();
         let mut socket = self.writer.lock().await;
         socket.write_all(&len).await?;
         socket.write_all(data).await?;
         Ok(())
     }
 
-    async fn recv_from(&self, data: &mut [u8]) -> anyhow::Result<(usize, NetworkAddr)> {
+    async fn recv_from(&self, data: &mut [u8]) -> Result<(usize, NetworkAddr), TransportError> {
         let mut socket = self.reader.lock().await;
         let mut len_buf = [0u8; 2];
         socket.read_exact(&mut len_buf).await?;
         let len = u16::from_be_bytes(len_buf) as usize;
         if data.len() < len {
-            return Err(anyhow::anyhow!("Buffer too small"));
+            return Err(TransportError::Internal("UDP-over-TCP buffer too small"));
         }
         socket.read_exact(&mut data[0..len]).await?;
         Ok((len, NetworkAddr::Raw(self.address)))

--- a/boltconn/src/app.rs
+++ b/boltconn/src/app.rs
@@ -101,8 +101,7 @@ impl App {
         // initialize resources
         let dns = {
             let bootstrap =
-                new_bootstrap_resolver(outbound_iface.as_str(), config.dns.bootstrap.as_slice())
-                    .unwrap();
+                new_bootstrap_resolver(outbound_iface.as_str(), config.dns.bootstrap.as_slice());
             let group = match parse_dns_config(config.dns.nameserver.iter(), Some(&bootstrap)).await
             {
                 Ok(g) => {
@@ -366,7 +365,7 @@ impl App {
         }
 
         let bootstrap =
-            new_bootstrap_resolver(&self.outbound_iface, config.dns.bootstrap.as_slice())?;
+            new_bootstrap_resolver(&self.outbound_iface, config.dns.bootstrap.as_slice());
         let group = parse_dns_config(config.dns.nameserver.iter(), Some(&bootstrap)).await?;
         let ns_policy = NameserverPolicies::new(
             &config.dns.nameserver_policy,

--- a/boltconn/src/config/error.rs
+++ b/boltconn/src/config/error.rs
@@ -16,6 +16,18 @@ pub enum ConfigError {
     TaskJoin(#[from] tokio::task::JoinError),
     #[error("Script error: {0}")]
     Script(#[from] ScriptError),
+    #[error("Interception error: {0}")]
+    Intercept(#[from] InterceptConfigError),
+}
+
+#[derive(Error, Debug)]
+pub enum InterceptConfigError {
+    #[error("Unknown rule: {0}")]
+    UnknownRule(String),
+    #[error("Bad url rule: {0}")]
+    BadUrl(String),
+    #[error("Bad header rule: {0}")]
+    BadHeader(String),
 }
 
 #[derive(Error, Debug)]
@@ -38,6 +50,8 @@ pub enum FileError {
     Serde(String, serde_yaml::Error),
     #[error("{0} serialization error: {1}")]
     Http(String, reqwest::Error),
+    #[error("Env variable error: {0}")]
+    Env(#[from] std::env::VarError),
 }
 
 #[derive(Error, Debug)]

--- a/boltconn/src/config/error.rs
+++ b/boltconn/src/config/error.rs
@@ -18,6 +18,8 @@ pub enum ConfigError {
     Script(#[from] ScriptError),
     #[error("Interception error: {0}")]
     Intercept(#[from] InterceptConfigError),
+    #[error("Internal error: {0}")]
+    Internal(&'static str),
 }
 
 #[derive(Error, Debug)]

--- a/boltconn/src/config/error.rs
+++ b/boltconn/src/config/error.rs
@@ -4,8 +4,8 @@ use thiserror::Error;
 pub enum ConfigError {
     #[error("File error: {0}")]
     File(#[from] FileError),
-    #[error("DNS")]
-    Dns,
+    #[error("DNS error: {0}")]
+    Dns(#[from] DnsConfigError),
     #[error("Rule error: {0}")]
     Rule(#[from] RuleError),
     #[error("Proxy error: {0}")]
@@ -16,6 +16,18 @@ pub enum ConfigError {
     TaskJoin(#[from] tokio::task::JoinError),
     #[error("Script error: {0}")]
     Script(#[from] ScriptError),
+}
+
+#[derive(Error, Debug)]
+pub enum DnsConfigError {
+    #[error("Invalid DNS: {0}")]
+    Invalid(String),
+    #[error("Invalid DNS type: {0}")]
+    InvalidType(String),
+    #[error("Invalid DNS preset for {0}: {1}")]
+    InvalidPreset(&'static str, String),
+    #[error("Runtime error for configuration: {0}")]
+    ResolveRuntimeInfo(#[from] crate::proxy::error::DnsError),
 }
 
 #[derive(Error, Debug)]

--- a/boltconn/src/config/error.rs
+++ b/boltconn/src/config/error.rs
@@ -1,0 +1,77 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("File error: {0}")]
+    File(#[from] FileError),
+    #[error("DNS")]
+    Dns,
+    #[error("Rule error: {0}")]
+    Rule(#[from] RuleError),
+    #[error("Proxy error: {0}")]
+    Proxy(#[from] ProxyError),
+    #[error("Provider error: {0}")]
+    Provider(#[from] ProviderError),
+    #[error("Runtime task join error: {0}")]
+    TaskJoin(#[from] tokio::task::JoinError),
+    #[error("Script error: {0}")]
+    Script(#[from] ScriptError),
+}
+
+#[derive(Error, Debug)]
+pub enum FileError {
+    #[error("{0} io error: {1}")]
+    Io(String, std::io::Error),
+    #[error("{0} deserialization error: {1}")]
+    Serde(String, serde_yaml::Error),
+    #[error("{0} serialization error: {1}")]
+    Http(String, reqwest::Error),
+}
+
+#[derive(Error, Debug)]
+pub enum ScriptError {
+    #[error("Script {0}: invalid type {1}")]
+    InvalidType(String, String),
+    #[error("Script {0} invalid filter {1}")]
+    InvalidFilter(String, String),
+}
+
+#[derive(Error, Debug)]
+pub enum RuleError {
+    #[error("Missing fallback rule")]
+    MissingFallback,
+    #[error("Invalid rule: {0}")]
+    Invalid(String),
+    #[error("Ruleset {0} exceeded limit")]
+    RulesetExceededLimit(String),
+}
+
+#[derive(Error, Debug)]
+pub enum ProviderError {
+    #[error("Missing provider: {0}")]
+    Missing(String),
+    #[error("Invalid provider: {0}")]
+    Invalid(String),
+    #[error("Provider {0} has bad filter: {1}")]
+    BadFilter(String, String),
+}
+
+#[derive(Error, Debug)]
+pub enum ProxyError {
+    #[error("Duplicate group name: {0}")]
+    DuplicateGroup(String),
+    #[error("Duplicate proxy name: {0}")]
+    DuplicateProxy(String),
+    #[error("Missing group: {0}")]
+    MissingGroup(String),
+    #[error("Missing proxy: {0}")]
+    MissingProxy(String),
+    #[error("Invalid proxy: {0}")]
+    Invalid(String),
+    #[error("Invalid Shadowsocks cipher {0} in proxy {1}")]
+    ShadowsocksCipher(String, String),
+    #[error("Proxy {0} error: {1}")]
+    ProxyFieldError(String, &'static str),
+    #[error("Unknown proxy {proxy} in group {group}")]
+    UnknownProxyInGroup { proxy: String, group: String },
+}

--- a/boltconn/src/config/module.rs
+++ b/boltconn/src/config/module.rs
@@ -1,7 +1,7 @@
 use crate::config::interception::InterceptionConfig;
 use crate::config::{
-    config::default_interception_vec, config::default_rule_provider, safe_join_path,
-    RuleConfigLine, RuleProvider,
+    config::default_interception_vec, config::default_rule_provider, safe_join_path, ConfigError,
+    FileError, RuleConfigLine, RuleProvider,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -44,10 +44,10 @@ pub async fn read_module_schema(
     config_path: &Path,
     modules: &[ModuleConfig],
     force_update: bool,
-) -> anyhow::Result<Vec<ModuleSchema>> {
+) -> Result<Vec<ModuleSchema>, ConfigError> {
     let mut list = Vec::new();
     // concurrently download rules
-    let tasks: Vec<JoinHandle<anyhow::Result<ModuleSchema>>> = modules
+    let tasks: Vec<JoinHandle<Result<ModuleSchema, ConfigError>>> = modules
         .iter()
         .cloned()
         .map(|cfg| {
@@ -55,21 +55,35 @@ pub async fn read_module_schema(
             tokio::spawn(async move {
                 match &cfg.content {
                     ModuleLocation::File { path } => {
+                        let io_error = |e| FileError::Io(path.clone(), e);
                         let content: ModuleSchema = serde_yaml::from_str(
-                            fs::read_to_string(safe_join_path(&root_path, path)?)?.as_str(),
-                        )?;
+                            fs::read_to_string(safe_join_path(&root_path, path).map_err(io_error)?)
+                                .map_err(io_error)?
+                                .as_str(),
+                        )
+                        .map_err(|e| FileError::Serde(path.clone(), e))?;
                         Ok(content)
                     }
                     ModuleLocation::Http { url, path, .. } => {
-                        let full_path = safe_join_path(&root_path, path)?;
+                        let io_error = |e| FileError::Io(path.clone(), e);
+                        let serde_error = |e| FileError::Serde(url.clone(), e);
+                        let http_error = |e| FileError::Http(url.clone(), e);
+
+                        let full_path = safe_join_path(&root_path, path).map_err(io_error)?;
                         let content: ModuleSchema = if !force_update && full_path.as_path().exists()
                         {
-                            serde_yaml::from_str(fs::read_to_string(full_path.as_path())?.as_str())?
+                            serde_yaml::from_str(
+                                fs::read_to_string(full_path.as_path())
+                                    .map_err(io_error)?
+                                    .as_str(),
+                            )
+                            .map_err(serde_error)?
                         } else {
-                            let resp = reqwest::get(url).await?;
-                            let text = resp.text().await?;
-                            let content: ModuleSchema = serde_yaml::from_str(text.as_str())?;
-                            fs::write(full_path.as_path(), text)?;
+                            let resp = reqwest::get(url).await.map_err(http_error)?;
+                            let text = resp.text().await.map_err(http_error)?;
+                            let content: ModuleSchema =
+                                serde_yaml::from_str(text.as_str()).map_err(serde_error)?;
+                            fs::write(full_path.as_path(), text).map_err(io_error)?;
                             content
                         };
                         Ok(content)
@@ -78,16 +92,10 @@ pub async fn read_module_schema(
             })
         })
         .collect();
-    for (idx, task) in tasks.into_iter().enumerate() {
+    for task in tasks.into_iter() {
         let content = match task.await? {
             Ok(c) => c,
-            Err(e) => {
-                return Err(anyhow::anyhow!(
-                    "In file {}: {}",
-                    modules.get(idx).unwrap().name,
-                    e
-                ))
-            }
+            Err(e) => return Err(e),
         };
         list.push(content);
     }

--- a/boltconn/src/dispatch/proxy.rs
+++ b/boltconn/src/dispatch/proxy.rs
@@ -1,8 +1,8 @@
 use crate::adapter::{HttpConfig, ShadowSocksConfig, Socks5Config};
+use crate::config::ProxyError;
 use crate::proxy::NetworkAddr;
 use crate::transport::trojan::TrojanConfig;
 use crate::transport::wireguard::WireguardConfig;
-use anyhow::anyhow;
 use arc_swap::ArcSwap;
 use shadowsocks::ServerAddr;
 use std::fmt::{Display, Formatter};
@@ -165,7 +165,7 @@ impl ProxyGroup {
         }
     }
 
-    pub fn set_selection(&self, name: &str) -> anyhow::Result<()> {
+    pub fn set_selection(&self, name: &str) -> Result<(), ProxyError> {
         for p in &self.proxies {
             match p {
                 GeneralProxy::Single(p) => {
@@ -184,7 +184,10 @@ impl ProxyGroup {
                 }
             }
         }
-        Err(anyhow!("Proxy not found"))
+        Err(ProxyError::UnknownProxyInGroup {
+            group: self.name.clone(),
+            proxy: name.to_string(),
+        })
     }
 }
 

--- a/boltconn/src/network/dns/ns_policy.rs
+++ b/boltconn/src/network/dns/ns_policy.rs
@@ -1,4 +1,5 @@
 use crate::common::host_matcher::{HostMatcher, HostMatcherBuilder};
+use crate::config::DnsConfigError;
 use crate::network::dns::parse_single_dns;
 use crate::network::dns::provider::IfaceProvider;
 use hickory_resolver::config::{NameServerConfigGroup, ResolverConfig, ResolverOpts};
@@ -16,13 +17,13 @@ impl NameserverPolicies {
         policies: &HashMap<String, String>,
         bootstrap: Option<&AsyncResolver<GenericConnector<IfaceProvider>>>,
         outbound_iface: &str,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self, DnsConfigError> {
         let mut builder: HashMap<(String, String), (HostMatcherBuilder, NameServerConfigGroup)> =
             HashMap::new();
         for (host, policy) in policies {
             let parts: Vec<&str> = policy.split(',').map(|s| s.trim()).collect();
             if parts.len() != 2 {
-                return Err(anyhow::anyhow!("Invalid dns format {}", policy));
+                return Err(DnsConfigError::Invalid(policy.clone()));
             }
             let key = (
                 parts.first().unwrap().to_string(),

--- a/boltconn/src/proxy/error.rs
+++ b/boltconn/src/proxy/error.rs
@@ -11,10 +11,22 @@ pub enum TransportError {
     Io(#[from] std::io::Error),
     #[error("ShadowSocks error: {0}")]
     ShadowSocks(&'static str),
+    #[error("HTTP proxy error: {0}")]
+    Http(&'static str),
     #[error("Socks5 error: {0}")]
     Socks5(#[from] fast_socks5::SocksError),
+    #[error("Socks5 error: {0}")]
+    Socks5Extra(&'static str),
     #[error("Trojan error: {0}")]
     Trojan(&'static str),
-    #[error("Unsupported SOCKS5 UDP fragment")]
-    UnsupportedSocks5UdpFragment,
+    #[error("WireGuard error: {0}")]
+    WireGuard(#[from] WireGuardError),
+}
+
+#[derive(Error, Debug)]
+pub enum WireGuardError {
+    #[error("WireGuard BoringTun error: {0}")]
+    BoringTun(&'static str),
+    #[error("WireGuard error: {0}")]
+    Others(&'static str),
 }

--- a/boltconn/src/proxy/error.rs
+++ b/boltconn/src/proxy/error.rs
@@ -1,0 +1,20 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum RuntimeError {}
+
+#[derive(Error, Debug)]
+pub enum TransportError {
+    #[error("Internal error: {0}")]
+    Internal(&'static str),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("ShadowSocks error: {0}")]
+    ShadowSocks(&'static str),
+    #[error("Socks5 error: {0}")]
+    Socks5(#[from] fast_socks5::SocksError),
+    #[error("Trojan error: {0}")]
+    Trojan(&'static str),
+    #[error("Unsupported SOCKS5 UDP fragment")]
+    UnsupportedSocks5UdpFragment,
+}

--- a/boltconn/src/proxy/error.rs
+++ b/boltconn/src/proxy/error.rs
@@ -9,6 +9,8 @@ pub enum TransportError {
     Internal(&'static str),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("DNS error: {0}")]
+    Dns(#[from] DnsError),
     #[error("ShadowSocks error: {0}")]
     ShadowSocks(&'static str),
     #[error("HTTP proxy error: {0}")]
@@ -21,6 +23,14 @@ pub enum TransportError {
     Trojan(&'static str),
     #[error("WireGuard error: {0}")]
     WireGuard(#[from] WireGuardError),
+}
+
+#[derive(Error, Debug)]
+pub enum DnsError {
+    #[error("Missing bootstrap DNS server for {0}")]
+    MissingBootstrap(String),
+    #[error("Failed to resolve dns server: {0}")]
+    ResolveServer(String),
 }
 
 #[derive(Error, Debug)]

--- a/boltconn/src/proxy/error.rs
+++ b/boltconn/src/proxy/error.rs
@@ -6,6 +6,18 @@ pub enum RuntimeError {
     Transport(#[from] TransportError),
     #[error("Intercept error: {0}")]
     Intercept(#[from] InterceptError),
+    #[error("Database error: {0}")]
+    Database(#[from] DatabaseError),
+    #[error("System error: {0}")]
+    System(#[from] SystemError),
+    #[error("Latency test: {0}")]
+    LatencyTest(&'static str),
+}
+
+#[derive(Error, Debug)]
+pub enum SystemError {
+    #[error("Controller error: {0}")]
+    Controller(std::io::Error),
 }
 
 #[derive(Error, Debug)]
@@ -74,4 +86,16 @@ pub enum CertificateError {
     RcGen(#[from] rcgen::RcgenError),
     #[error("PemFile error: {0}")]
     PemFile(std::io::Error),
+}
+
+#[derive(Error, Debug)]
+pub enum DatabaseError {
+    #[error("RuSqlite error: {0}")]
+    RuSqlite(#[from] rusqlite::Error),
+    #[error("Missing table: {0}")]
+    MissingTable(&'static str),
+    #[error("Invalid table schema {0}")]
+    InvalidSchema(&'static str),
+    #[error("Chown error: {0}")]
+    Chown(nix::Error),
 }

--- a/boltconn/src/proxy/error.rs
+++ b/boltconn/src/proxy/error.rs
@@ -1,7 +1,12 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum RuntimeError {}
+pub enum RuntimeError {
+    #[error("Transport error: {0}")]
+    Transport(#[from] TransportError),
+    #[error("Intercept error: {0}")]
+    Intercept(#[from] InterceptError),
+}
 
 #[derive(Error, Debug)]
 pub enum TransportError {
@@ -39,4 +44,34 @@ pub enum WireGuardError {
     BoringTun(&'static str),
     #[error("WireGuard error: {0}")]
     Others(&'static str),
+}
+
+#[derive(Error, Debug)]
+pub enum InterceptError {
+    #[error("No corresponding id: {0}")]
+    NoCorrespondingId(u64),
+    #[error("Wait response: {0}")]
+    WaitResponse(hyper::Error),
+    #[error("Invalid data")]
+    InvalidData,
+    #[error("Tls connect error: {0}")]
+    TlsConnect(std::io::Error),
+    #[error("Handshake error: {0}")]
+    Handshake(hyper::Error),
+    #[error("Send request error: {0}")]
+    SendRequest(hyper::Error),
+    #[error("Certificate error: {0}")]
+    Certificate(#[from] CertificateError),
+}
+
+#[derive(Error, Debug)]
+pub enum CertificateError {
+    #[error("No generated private key available")]
+    NoPrivateKey,
+    #[error("No generated certificate available")]
+    NoCert,
+    #[error("RcGen error: {0}")]
+    RcGen(#[from] rcgen::RcgenError),
+    #[error("PemFile error: {0}")]
+    PemFile(std::io::Error),
 }

--- a/boltconn/src/proxy/mixed_inbound.rs
+++ b/boltconn/src/proxy/mixed_inbound.rs
@@ -1,3 +1,4 @@
+use crate::proxy::error::TransportError;
 use crate::proxy::{Dispatcher, HttpInbound, Socks5Inbound};
 use std::collections::HashMap;
 use std::io;
@@ -62,7 +63,7 @@ impl MixedInbound {
         socks_auth: Arc<HashMap<String, String>>,
         src_addr: SocketAddr,
         dispatcher: Arc<Dispatcher>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), TransportError> {
         let mut first_byte = [0u8; 1];
         socks_stream.read_exact(&mut first_byte).await?;
         const C_ASCII: u8 = b"C"[0];

--- a/boltconn/src/proxy/mod.rs
+++ b/boltconn/src/proxy/mod.rs
@@ -1,5 +1,6 @@
 mod context;
 mod dispatcher;
+pub mod error;
 mod http_inbound;
 mod manager;
 mod mixed_inbound;

--- a/boltconn/src/transport/mod.rs
+++ b/boltconn/src/transport/mod.rs
@@ -1,3 +1,4 @@
+use crate::proxy::error::TransportError;
 use crate::proxy::NetworkAddr;
 use async_trait::async_trait;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -9,10 +10,10 @@ pub mod wireguard;
 
 #[async_trait]
 pub trait UdpSocketAdapter: Send + Sync {
-    async fn send_to(&self, data: &[u8], addr: NetworkAddr) -> anyhow::Result<()>;
+    async fn send_to(&self, data: &[u8], addr: NetworkAddr) -> Result<(), TransportError>;
 
     // @return: <length>, <if addr matches target>
-    async fn recv_from(&self, data: &mut [u8]) -> anyhow::Result<(usize, NetworkAddr)>;
+    async fn recv_from(&self, data: &mut [u8]) -> Result<(usize, NetworkAddr), TransportError>;
 }
 
 pub enum AdapterOrSocket {

--- a/boltconn/src/transport/wireguard.rs
+++ b/boltconn/src/transport/wireguard.rs
@@ -2,6 +2,8 @@ use crate::common::io_err;
 use crate::common::MAX_PKT_SIZE;
 use crate::config::DnsPreference;
 use crate::network::dns::Dns;
+use crate::proxy::error::TransportError;
+use crate::proxy::error::WireGuardError::BoringTun;
 use crate::proxy::NetworkAddr;
 use crate::transport::AdapterOrSocket;
 use boringtun::noise::errors::WireGuardError;
@@ -88,7 +90,7 @@ impl WireguardTunnel {
         config: &WireguardConfig,
         dns: Arc<Dns>,
         smol_notify: Arc<Notify>,
-    ) -> anyhow::Result<Self> {
+    ) -> Result<Self, TransportError> {
         let endpoint = match config.endpoint {
             NetworkAddr::Raw(addr) => addr,
             NetworkAddr::DomainName {
@@ -110,7 +112,7 @@ impl WireguardTunnel {
             13,
             None,
         )
-        .map_err(|e| anyhow::anyhow!(e))?;
+        .map_err(|e| TransportError::WireGuard(BoringTun(e)))?;
         Ok(Self {
             tunnel: tokio::sync::Mutex::new(tunnel),
             inner: WireguardTunnelInner {


### PR DESCRIPTION
Replace most of the internal error type from `anyhow::Error` to more concrete types. `anyhow` is still used for CLI and the most top module for now.