### PR TITLE
feat: SSH as proxy outbound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +457,17 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2 0.12.2",
+ "sha2",
+]
 
 [[package]]
 name = "bindgen"
@@ -540,6 +557,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
+]
+
+[[package]]
 name = "boltapi"
 version = "0.1.0"
 dependencies = [
@@ -610,6 +646,7 @@ dependencies = [
  "reqwest",
  "rquickjs",
  "rusqlite",
+ "russh",
  "rustls-pemfile 2.1.1",
  "serde",
  "serde_json",
@@ -637,8 +674,7 @@ dependencies = [
 [[package]]
 name = "boringtun"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751787b019c674b9ac353f4eaa285e6711c21badb421cd8c199bf2c83b727f29"
+source = "git+https://github.com/XOR-op/boringtun?branch=master#f672bb6c1e1e371240a8d151f15854687eb740bb"
 dependencies = [
  "aead",
  "base64 0.13.1",
@@ -652,7 +688,7 @@ dependencies = [
  "nix 0.25.1",
  "parking_lot",
  "rand_core",
- "ring 0.16.20",
+ "ring 0.17.8",
  "tracing",
  "untrusted 0.9.0",
  "x25519-dalek",
@@ -702,6 +738,15 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -995,6 +1040,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,15 +1073,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-rc.3"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436ace70fc06e06f7f689d2624dc4e2f0ea666efb5aa704215f7249ae6e047a7"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
+ "digest",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1144,6 +1201,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,12 +1235,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1200,9 +1278,23 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
- "elliptic-curve",
- "signature",
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.9",
+ "digest",
+ "elliptic-curve 0.13.8",
+ "rfc6979",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1211,7 +1303,32 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519 2.2.3",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1238,13 +1355,34 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "der",
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
  "digest",
  "generic-array",
  "rand_core",
- "sec1",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8 0.10.2",
+ "rand_core",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -1372,10 +1510,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
-name = "fiat-crypto"
-version = "0.1.20"
+name = "ff"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "flate2"
@@ -1511,12 +1659,13 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1553,6 +1702,17 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -1689,6 +1849,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hickory-proto"
@@ -2017,6 +2183,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -2131,6 +2298,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "lazycell"
@@ -2153,6 +2323,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -2467,6 +2643,24 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -2486,12 +2680,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2589,8 +2795,20 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -2599,8 +2817,34 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+dependencies = [
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct 0.2.0",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder",
+ "rand_core",
+ "sha2",
 ]
 
 [[package]]
@@ -2633,10 +2877,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -2652,6 +2929,15 @@ checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
  "base64 0.22.1",
  "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2693,13 +2979,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.9",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der 0.7.9",
+ "pbkdf2 0.12.2",
+ "scrypt",
+ "sha2",
+ "spki 0.7.3",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.9",
+ "pkcs5",
+ "rand_core",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2707,12 +3031,6 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
-
-[[package]]
-name = "platforms"
-version = "3.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
 
 [[package]]
 name = "poly1305"
@@ -2757,6 +3075,15 @@ checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
 dependencies = [
  "proc-macro2",
  "syn 2.0.32",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -3021,6 +3348,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,15 +3395,15 @@ checksum = "333b9bf6765e0141324d95b5375bb1aa5267865bb4bc0281c22aff22f5d37746"
 dependencies = [
  "aead",
  "digest",
- "ecdsa",
- "ed25519",
+ "ecdsa 0.14.8",
+ "ed25519 1.5.3",
  "generic-array",
  "opaque-debug",
- "p256",
- "p384",
- "pkcs8",
+ "p256 0.11.1",
+ "p384 0.11.2",
+ "pkcs8 0.9.0",
  "ring 0.16.20",
- "signature",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -3119,6 +3456,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.10.2",
+ "rand_core",
+ "sha2",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3130,6 +3488,110 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "russh"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a229f2a03daea3f62cee897b40329ce548600cca615906d98d58b8db3029b19"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "async-trait",
+ "bitflags 2.4.0",
+ "byteorder",
+ "cbc",
+ "chacha20",
+ "ctr",
+ "curve25519-dalek",
+ "des",
+ "digest",
+ "elliptic-curve 0.13.8",
+ "flate2",
+ "futures",
+ "generic-array",
+ "hex-literal",
+ "hmac",
+ "log",
+ "num-bigint",
+ "once_cell",
+ "p256 0.13.2",
+ "p384 0.13.0",
+ "p521",
+ "poly1305",
+ "rand",
+ "rand_core",
+ "russh-cryptovec",
+ "russh-keys",
+ "sha1",
+ "sha2",
+ "ssh-encoding",
+ "ssh-key",
+ "subtle",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadd2c0ab350e21c66556f94ee06f766d8bdae3213857ba7610bfd8e10e51880"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "russh-keys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89757474f7c9ee30121d8cc7fe293a954ba10b204a82ccf5850a5352a532ebc7"
+dependencies = [
+ "aes",
+ "async-trait",
+ "bcrypt-pbkdf",
+ "block-padding",
+ "byteorder",
+ "cbc",
+ "ctr",
+ "data-encoding",
+ "der 0.7.9",
+ "digest",
+ "ecdsa 0.16.9",
+ "ed25519-dalek",
+ "elliptic-curve 0.13.8",
+ "futures",
+ "hmac",
+ "home",
+ "inout",
+ "log",
+ "md5",
+ "num-integer",
+ "p256 0.13.2",
+ "p384 0.13.0",
+ "p521",
+ "pbkdf2 0.11.0",
+ "pkcs1",
+ "pkcs5",
+ "pkcs8 0.10.2",
+ "rand",
+ "rand_core",
+ "rsa",
+ "russh-cryptovec",
+ "sec1 0.7.3",
+ "serde",
+ "sha1",
+ "sha2",
+ "spki 0.7.3",
+ "ssh-encoding",
+ "ssh-key",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -3275,6 +3737,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3285,6 +3756,17 @@ name = "scratch"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5e082f6ea090deaf0e6dd04b68360fd5cddb152af6ce8927c9d25db299f98c"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2 0.12.2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "sct"
@@ -3302,9 +3784,23 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.1.1",
+ "der 0.6.1",
  "generic-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.9",
+ "generic-array",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -3504,6 +4000,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3575,7 +4081,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.9",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "chacha20",
+ "cipher",
+ "ctr",
+ "poly1305",
+ "ssh-encoding",
+ "subtle",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468",
+ "sha2",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca9b366a80cf18bb6406f4cf4d10aebfb46140a8c0c33f666a144c5c76ecbafc"
+dependencies = [
+ "bcrypt-pbkdf",
+ "ed25519-dalek",
+ "num-bigint-dig",
+ "p256 0.13.2",
+ "p384 0.13.0",
+ "p521",
+ "rand_core",
+ "rsa",
+ "sec1 0.7.3",
+ "sha2",
+ "signature 2.2.0",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4027,11 +4594,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -4040,20 +4606,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.32",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4182,9 +4748,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-bidi"
@@ -4738,9 +5304,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7fae07da688e17059d5886712c933bb0520f15eff2e09cfa18e30968f4e63a"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ debug = true
 [patch.crates-io]
 rustls = { git = "https://github.com/XOR-op/rustls.delta.git", branch = "unofficial-rel-0.23" }
 smoltcp = { git = "https://github.com/XOR-op/smoltcp.git", branch = "resize-recv-buffer" }
+# Only used to bump x25519-dalek; will be removed once 0.6.1 is released
+boringtun = { git = "https://github.com/XOR-op/boringtun", branch = "master"}

--- a/boltconn/Cargo.toml
+++ b/boltconn/Cargo.toml
@@ -72,7 +72,7 @@ rquickjs = { version = "0.6.2", features = ["bindgen", "futures", "macro", "clas
 rusqlite = { version = "0.29.0", features = ["bundled"] }
 rustls-pemfile = "2.1.1"
 webpki-roots = "0.26.1"
-x25519-dalek = "2.0.0-pre.1"
+x25519-dalek = "2.0.1"
 interpolator = "0.5.0"
 # Proxies
 fast-socks5 = "0.9.1"
@@ -88,6 +88,7 @@ tabular = "0.2.0"
 
 # features(tokio-console)
 console-subscriber = { version = "0.1.10", optional = true }
+russh = "0.45.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libproc = "0.13.0"

--- a/boltconn/src/adapter/mod.rs
+++ b/boltconn/src/adapter/mod.rs
@@ -416,3 +416,18 @@ async fn lookup(dns: &Dns, addr: &NetworkAddr) -> io::Result<SocketAddr> {
         }
     })
 }
+
+pub(super) async fn get_dst(dns: &Dns, dst: &NetworkAddr) -> io::Result<SocketAddr> {
+    Ok(match dst {
+        NetworkAddr::DomainName { domain_name, port } => {
+            // translate fake ip
+            SocketAddr::new(
+                dns.genuine_lookup(domain_name.as_str())
+                    .await
+                    .ok_or_else(|| io_err("DNS failed"))?,
+                *port,
+            )
+        }
+        NetworkAddr::Raw(s) => *s,
+    })
+}

--- a/boltconn/src/adapter/mod.rs
+++ b/boltconn/src/adapter/mod.rs
@@ -16,6 +16,7 @@ mod direct;
 mod http;
 mod shadowsocks;
 mod socks5;
+mod ssh;
 mod tcp_adapter;
 mod trojan;
 mod udp_adapter;

--- a/boltconn/src/adapter/mod.rs
+++ b/boltconn/src/adapter/mod.rs
@@ -34,6 +34,7 @@ use crate::transport::UdpSocketAdapter;
 pub use chain::*;
 pub use direct::*;
 pub use socks5::*;
+pub use ssh::*;
 use std::future::Future;
 use std::io::ErrorKind;
 pub use tcp_adapter::*;

--- a/boltconn/src/adapter/ssh.rs
+++ b/boltconn/src/adapter/ssh.rs
@@ -1,7 +1,14 @@
+use crate::adapter;
+use crate::common::duplex_chan::DuplexChan;
 use crate::network::dns::Dns;
+use crate::network::egress::Egress;
+use crate::proxy::error::TransportError;
 use crate::proxy::NetworkAddr;
-use crate::transport::ssh::SshConfig;
+use crate::transport::ssh::{SshConfig, SshTunnel};
+use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 #[derive(Clone)]
 pub struct SshOutboundHandle {
@@ -19,5 +26,70 @@ impl SshOutboundHandle {
             dns,
             config,
         }
+    }
+}
+
+pub struct SshManager {
+    iface: String,
+    // We use an async wrapper to avoid deadlock in DashMap
+    active_conn: tokio::sync::Mutex<HashMap<SshConfig, Arc<SshTunnel>>>,
+    server_resolver: Arc<Dns>,
+    timeout: Duration,
+}
+
+impl SshManager {
+    pub fn new(iface: &str, dns: Arc<Dns>, timeout: Duration) -> Self {
+        Self {
+            iface: iface.to_string(),
+            active_conn: Default::default(),
+            server_resolver: dns,
+            timeout,
+        }
+    }
+
+    pub async fn get_ssh_conn(
+        &self,
+        config: &SshConfig,
+        next_step: Option<DuplexChan>,
+        ret_tx: tokio::sync::oneshot::Sender<bool>,
+    ) -> Result<Arc<SshTunnel>, TransportError> {
+        for _ in 0..10 {
+            // get an existing conn, or create
+            let mut guard = self.active_conn.lock().await;
+            if let Some(endpoint) = guard.get(config) {
+                if endpoint.is_active() {
+                    let _ = ret_tx.send(false);
+                    return Ok(endpoint.clone());
+                } else {
+                    guard.remove(config);
+                    continue;
+                }
+            } else {
+                let _ = ret_tx.send(true);
+                let tunnel = Arc::new(match next_step {
+                    Some(next_step) => SshTunnel::new(config, next_step).await?,
+                    None => {
+                        let server_addr =
+                            adapter::get_dst(&self.server_resolver, &config.server).await?;
+                        let stream = match server_addr {
+                            SocketAddr::V4(_) => {
+                                Egress::new(self.iface.as_str())
+                                    .tcpv4_stream(server_addr)
+                                    .await?
+                            }
+                            SocketAddr::V6(_) => {
+                                Egress::new(self.iface.as_str())
+                                    .tcpv6_stream(server_addr)
+                                    .await?
+                            }
+                        };
+                        SshTunnel::new(config, stream).await?
+                    }
+                });
+                guard.insert(config.clone(), tunnel.clone());
+                return Ok(tunnel);
+            }
+        }
+        Err(TransportError::Ssh(russh::Error::ConnectionTimeout))
     }
 }

--- a/boltconn/src/adapter/ssh.rs
+++ b/boltconn/src/adapter/ssh.rs
@@ -24,7 +24,7 @@ pub struct SshOutboundHandle {
     iface_name: String,
     dst: NetworkAddr,
     dns: Arc<Dns>,
-    config: Arc<SshConfig>,
+    config: SshConfig,
     manager: Arc<SshManager>,
 }
 
@@ -33,7 +33,7 @@ impl SshOutboundHandle {
         iface_name: &str,
         dst: NetworkAddr,
         dns: Arc<Dns>,
-        config: Arc<SshConfig>,
+        config: SshConfig,
         manager: Arc<SshManager>,
     ) -> Self {
         Self {
@@ -54,7 +54,7 @@ impl SshOutboundHandle {
     ) -> Result<(), TransportError> {
         let master_conn = self
             .manager
-            .get_ssh_conn(self.config.as_ref(), outbound, completion_tx)
+            .get_ssh_conn(&self.config, outbound, completion_tx)
             .await?;
         let channel = master_conn.new_mapped_connection(self.dst.clone()).await?;
         established_tcp(inbound, channel, abort_handle).await;

--- a/boltconn/src/adapter/ssh.rs
+++ b/boltconn/src/adapter/ssh.rs
@@ -1,0 +1,23 @@
+use crate::network::dns::Dns;
+use crate::proxy::NetworkAddr;
+use crate::transport::ssh::SshConfig;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct SshOutboundHandle {
+    iface_name: String,
+    dst: NetworkAddr,
+    dns: Arc<Dns>,
+    config: Arc<SshConfig>,
+}
+
+impl SshOutboundHandle {
+    pub fn new(iface_name: &str, dst: NetworkAddr, dns: Arc<Dns>, config: Arc<SshConfig>) -> Self {
+        Self {
+            iface_name: iface_name.to_string(),
+            dst,
+            dns,
+            config,
+        }
+    }
+}

--- a/boltconn/src/adapter/wireguard.rs
+++ b/boltconn/src/adapter/wireguard.rs
@@ -6,7 +6,7 @@ use crate::adapter::udp_over_tcp::UdpOverTcpAdapter;
 use crate::common::{io_err, local_async_run, AbortCanary, StreamOutboundTrait, MAX_PKT_SIZE};
 use crate::network::dns::{Dns, GenericDns};
 use crate::network::egress::Egress;
-use crate::proxy::error::{TransportError, WireGuardError};
+use crate::proxy::error::TransportError;
 use crate::proxy::{ConnAbortHandle, NetworkAddr};
 use crate::transport::smol::{SmolDnsProvider, SmolStack, VirtualIpDevice};
 use crate::transport::wireguard::{WireguardConfig, WireguardTunnel};
@@ -312,9 +312,9 @@ impl WireguardManager {
                 return Ok(ep);
             }
         }
-        Err(TransportError::WireGuard(WireGuardError::Others(
+        Err(TransportError::WireGuard(
             "get_wg_conn: unexpected loop time",
-        )))
+        ))
     }
 }
 

--- a/boltconn/src/app.rs
+++ b/boltconn/src/app.rs
@@ -146,6 +146,7 @@ impl App {
         let ruleset = load_rulesets(&loaded_config)?;
         let dispatching = Arc::new(
             DispatchingBuilder::new(
+                config_path.as_path(),
                 dns.clone(),
                 mmdb.clone(),
                 &loaded_config,
@@ -161,6 +162,7 @@ impl App {
                 .map_err(|e| anyhow!("Load certs from path {:?} failed: {}", cert_path, e))?;
             let interception_mgr = Arc::new(
                 InterceptionManager::new(
+                    config_path.as_path(),
                     config.interception.as_slice(),
                     dns.clone(),
                     mmdb.clone(),
@@ -295,6 +297,7 @@ impl App {
         .await?;
         let dispatching = {
             let builder = DispatchingBuilder::new(
+                self.config_path.as_path(),
                 self.dns.clone(),
                 mmdb.clone(),
                 &loaded_config,
@@ -306,6 +309,7 @@ impl App {
 
         let interception_mgr = Arc::new(
             InterceptionManager::new(
+                self.config_path.as_path(),
                 config.interception.as_slice(),
                 self.dns.clone(),
                 mmdb.clone(),
@@ -365,6 +369,7 @@ pub async fn validate_config(
     // dispatch
     let ruleset = load_rulesets(&loaded_config)?;
     let _dispatching = DispatchingBuilder::new(
+        config_path,
         dns.clone(),
         mmdb.clone(),
         &loaded_config,
@@ -373,9 +378,15 @@ pub async fn validate_config(
     )
     .and_then(|b| b.build(&loaded_config))
     .map_err(|e| anyhow!("Parse routing rules failed: {}", e))?;
-    let _interception_mgr =
-        InterceptionManager::new(config.interception.as_slice(), dns, mmdb, &ruleset, msg_bus)
-            .map_err(|e| anyhow!("Load intercept rules failed: {}", e))?;
+    let _interception_mgr = InterceptionManager::new(
+        config_path,
+        config.interception.as_slice(),
+        dns,
+        mmdb,
+        &ruleset,
+        msg_bus,
+    )
+    .map_err(|e| anyhow!("Load intercept rules failed: {}", e))?;
     Ok(())
 }
 

--- a/boltconn/src/config/config.rs
+++ b/boltconn/src/config/config.rs
@@ -3,6 +3,7 @@ use crate::config::interception::InterceptionConfig;
 use crate::config::proxy_group::RawProxyGroupCfg;
 use crate::config::{
     AuthData, ModuleConfig, PortOrSocketAddr, ProxyProvider, RuleConfigLine, RuleProvider,
+    SingleOrVec,
 };
 use linked_hash_map::LinkedHashMap;
 use serde::{Deserialize, Serialize};
@@ -174,7 +175,7 @@ pub enum RawProxyLocalCfg {
         #[serde(alias = "key-passphrase")]
         key_passphrase: Option<String>,
         #[serde(alias = "host-pubkey")]
-        host_pubkey: Option<String>,
+        host_pubkey: Option<SingleOrVec<String>>,
     },
 }
 

--- a/boltconn/src/config/config.rs
+++ b/boltconn/src/config/config.rs
@@ -8,6 +8,7 @@ use linked_hash_map::LinkedHashMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
@@ -161,6 +162,19 @@ pub enum RawProxyLocalCfg {
         reserved: Option<[u8; 3]>,
         #[serde(alias = "over-tcp", default = "default_false")]
         over_tcp: bool,
+    },
+    #[serde(alias = "ssh")]
+    Ssh {
+        server: RawServerAddr,
+        port: u16,
+        user: String,
+        password: Option<String>,
+        #[serde(alias = "private-key")]
+        private_key: Option<PathBuf>,
+        #[serde(alias = "key-passphrase")]
+        key_passphrase: Option<String>,
+        #[serde(alias = "host-pubkey")]
+        host_pubkey: Option<String>,
     },
 }
 

--- a/boltconn/src/dispatch/dispatching.rs
+++ b/boltconn/src/dispatch/dispatching.rs
@@ -16,6 +16,7 @@ use crate::instrument::bus::MessageBus;
 use crate::network::dns::Dns;
 use crate::platform::process::{NetworkType, ProcessInfo};
 use crate::proxy::NetworkAddr;
+use crate::transport::ssh::{SshAuthentication, SshConfig};
 use crate::transport::trojan::TrojanConfig;
 use crate::transport::wireguard::WireguardConfig;
 use arc_swap::ArcSwap;
@@ -27,6 +28,7 @@ use shadowsocks::crypto::CipherKind;
 use shadowsocks::ServerAddr;
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, SocketAddr};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 pub struct ConnInfo {
@@ -99,6 +101,7 @@ fn stringfy_process(info: &ConnInfo) -> &str {
 
 #[derive(Clone)]
 pub struct DispatchingBuilder {
+    config_path: PathBuf,
     proxies: HashMap<String, Arc<Proxy>>,
     groups: HashMap<String, Arc<ProxyGroup>>,
     rulesets: HashMap<String, Arc<RuleSet>>,
@@ -109,8 +112,14 @@ pub struct DispatchingBuilder {
 }
 
 impl DispatchingBuilder {
-    pub fn empty(dns: Arc<Dns>, mmdb: Option<Arc<MmdbReader>>, msg_bus: Arc<MessageBus>) -> Self {
+    pub fn empty(
+        config_path: &Path,
+        dns: Arc<Dns>,
+        mmdb: Option<Arc<MmdbReader>>,
+        msg_bus: Arc<MessageBus>,
+    ) -> Self {
         let mut builder = Self {
+            config_path: config_path.to_path_buf(),
             proxies: Default::default(),
             groups: Default::default(),
             rulesets: Default::default(),
@@ -135,13 +144,14 @@ impl DispatchingBuilder {
     }
 
     pub fn new(
+        config_path: &Path,
         dns: Arc<Dns>,
         mmdb: Option<Arc<MmdbReader>>,
         loaded_config: &LoadedConfig,
         ruleset: &RuleSetTable,
         msg_bus: Arc<MessageBus>,
     ) -> Result<Self, ConfigError> {
-        let mut builder = Self::empty(dns, mmdb, msg_bus);
+        let mut builder = Self::empty(config_path, dns, mmdb, msg_bus);
         // start init
         let LoadedConfig {
             config,
@@ -521,6 +531,71 @@ impl DispatchingBuilder {
                         }),
                     ))
                 }
+                RawProxyLocalCfg::Ssh {
+                    server,
+                    port,
+                    user,
+                    password,
+                    private_key,
+                    key_passphrase,
+                    host_pubkey,
+                } => {
+                    // construct authentication data
+                    let auth = if let Some(key_path) = private_key {
+                        let key_content = russh::keys::load_secret_key(
+                            get_file_path(self.config_path.as_path(), key_path).ok_or_else(
+                                || {
+                                    ProxyError::ProxyFieldError(
+                                        name.clone(),
+                                        "Invalid private key path",
+                                    )
+                                },
+                            )?,
+                            key_passphrase.as_ref().map(|s| s.as_str()),
+                        )
+                        .map_err(|_| {
+                            ProxyError::ProxyFieldError(name.clone(), "Load private key file")
+                        })?;
+                        SshAuthentication::PrivateKey(Arc::new(key_content))
+                    } else if let Some(passwd) = password {
+                        SshAuthentication::Password(passwd.clone())
+                    } else {
+                        return Err(ProxyError::ProxyFieldError(
+                            name.clone(),
+                            "No authentication method configured for the SSH outbound",
+                        )
+                        .into());
+                    };
+                    // validate server's identity
+                    let host_pubkey = if let Some(pubkey) = host_pubkey {
+                        let (key_type, content) = pubkey.split_once(' ').ok_or_else(|| {
+                            ProxyError::ProxyFieldError(
+                                name.clone(),
+                                "Invalid host public key format; expect '<key-type> <base64-data>'",
+                            )
+                        })?;
+                        Some((
+                            key_type.to_string(),
+                            russh::keys::parse_public_key_base64(content).map_err(|_| {
+                                ProxyError::ProxyFieldError(
+                                name.clone(),
+                                "Invalid host public key format; expect '<key-type> <base64-data>'",
+                            )
+                            })?,
+                        ))
+                    } else {
+                        None
+                    };
+                    Arc::new(Proxy::new(
+                        name.clone(),
+                        ProxyImpl::Ssh(SshConfig {
+                            server: NetworkAddr::from(server, *port),
+                            user: user.clone(),
+                            auth,
+                            host_pubkey,
+                        }),
+                    ))
+                }
             };
             self.proxies.insert(name.to_string(), p);
         }
@@ -792,4 +867,15 @@ impl DispatchingSnippet {
         }
         (name, proxy_impl, iface)
     }
+}
+
+fn get_file_path(config_path: &Path, path: &Path) -> Option<PathBuf> {
+    Some(if path.is_absolute() {
+        path.to_path_buf()
+    } else if path.to_string_lossy().starts_with("~/") {
+        let home = PathBuf::from(std::env::var("HOME").ok()?);
+        home.join(path.to_string_lossy().strip_prefix("~/")?)
+    } else {
+        config_path.join(path)
+    })
 }

--- a/boltconn/src/dispatch/proxy.rs
+++ b/boltconn/src/dispatch/proxy.rs
@@ -1,6 +1,7 @@
 use crate::adapter::{HttpConfig, ShadowSocksConfig, Socks5Config};
 use crate::config::ProxyError;
 use crate::proxy::NetworkAddr;
+use crate::transport::ssh::SshConfig;
 use crate::transport::trojan::TrojanConfig;
 use crate::transport::wireguard::WireguardConfig;
 use arc_swap::ArcSwap;
@@ -58,6 +59,7 @@ pub enum ProxyImpl {
     Shadowsocks(ShadowSocksConfig),
     Trojan(TrojanConfig),
     Wireguard(WireguardConfig),
+    Ssh(SshConfig),
     Chain(Vec<GeneralProxy>),
 }
 
@@ -72,6 +74,7 @@ impl ProxyImpl {
             ProxyImpl::Shadowsocks(c) => c.udp,
             ProxyImpl::Trojan(c) => c.udp,
             ProxyImpl::Wireguard(_) => true,
+            ProxyImpl::Ssh(_) => false,
             // since it's hard to determine, we just assume it true
             ProxyImpl::Chain(_) => true,
         }
@@ -87,6 +90,7 @@ impl ProxyImpl {
             ProxyImpl::Shadowsocks(_) => "shadowsocks",
             ProxyImpl::Trojan(_) => "trojan",
             ProxyImpl::Wireguard(_) => "wireguard",
+            ProxyImpl::Ssh(_) => "ssh",
             ProxyImpl::Chain(_) => "chain",
         }
         .to_string()
@@ -107,6 +111,7 @@ impl ProxyImpl {
             }),
             ProxyImpl::Trojan(c) => Some(c.server_addr.clone()),
             ProxyImpl::Wireguard(c) => Some(c.endpoint.clone()),
+            ProxyImpl::Ssh(c) => Some(c.server.clone()),
         }
     }
 }

--- a/boltconn/src/intercept/intercept_manager.rs
+++ b/boltconn/src/intercept/intercept_manager.rs
@@ -4,6 +4,7 @@ use crate::external::MmdbReader;
 use crate::instrument::bus::MessageBus;
 use crate::intercept::{HeaderEngine, ScriptEngine, UrlEngine};
 use crate::network::dns::Dns;
+use std::path::Path;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -104,6 +105,7 @@ pub struct InterceptionManager {
 
 impl InterceptionManager {
     pub fn new(
+        config_path: &Path,
         entries: &[InterceptionConfig],
         dns: Arc<Dns>,
         mmdb: Option<Arc<MmdbReader>>,
@@ -115,8 +117,9 @@ impl InterceptionManager {
             if !i.enabled {
                 continue;
             }
-            let filters = DispatchingBuilder::empty(dns.clone(), mmdb.clone(), msg_bus.clone())
-                .build_filter(i.filters.as_slice(), rulesets)?;
+            let filters =
+                DispatchingBuilder::empty(config_path, dns.clone(), mmdb.clone(), msg_bus.clone())
+                    .build_filter(i.filters.as_slice(), rulesets)?;
             let payload = InterceptionPayload::parse_actions(i.actions.as_slice())?;
             res.push(InterceptionEntry {
                 filters,

--- a/boltconn/src/network/egress.rs
+++ b/boltconn/src/network/egress.rs
@@ -37,13 +37,13 @@ impl Egress {
         }
     }
 
-    pub async fn tcpv4_stream(&self, addr: SocketAddr) -> Result<TcpStream> {
+    async fn tcpv4_stream(&self, addr: SocketAddr) -> Result<TcpStream> {
         let socket = TcpSocket::new_v4()?;
         platform::bind_to_device(socket.as_raw_fd(), self.iface_name.as_str())?;
         socket.connect(addr).await
     }
 
-    pub async fn tcpv6_stream(&self, addr: SocketAddr) -> Result<TcpStream> {
+    async fn tcpv6_stream(&self, addr: SocketAddr) -> Result<TcpStream> {
         let socket = TcpSocket::new_v6()?;
         platform::bind_to_device(socket.as_raw_fd(), self.iface_name.as_str())?;
         socket.connect(addr).await

--- a/boltconn/src/proxy/error.rs
+++ b/boltconn/src/proxy/error.rs
@@ -41,7 +41,7 @@ pub enum TransportError {
     #[error("Trojan error: {0}")]
     Trojan(&'static str),
     #[error("WireGuard error: {0}")]
-    WireGuard(#[from] WireGuardError),
+    WireGuard(&'static str),
 }
 
 #[derive(Error, Debug)]
@@ -50,14 +50,6 @@ pub enum DnsError {
     MissingBootstrap(String),
     #[error("Failed to resolve dns server: {0}")]
     ResolveServer(String),
-}
-
-#[derive(Error, Debug)]
-pub enum WireGuardError {
-    #[error("WireGuard BoringTun error: {0}")]
-    BoringTun(&'static str),
-    #[error("WireGuard error: {0}")]
-    Others(&'static str),
 }
 
 #[derive(Error, Debug)]

--- a/boltconn/src/proxy/error.rs
+++ b/boltconn/src/proxy/error.rs
@@ -42,6 +42,8 @@ pub enum TransportError {
     Trojan(&'static str),
     #[error("WireGuard error: {0}")]
     WireGuard(&'static str),
+    #[error("SSH error: {0}")]
+    Ssh(#[from] russh::Error),
 }
 
 #[derive(Error, Debug)]

--- a/boltconn/src/transport/mod.rs
+++ b/boltconn/src/transport/mod.rs
@@ -5,6 +5,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 
 pub mod smol;
+pub mod ssh;
 pub mod trojan;
 pub mod wireguard;
 

--- a/boltconn/src/transport/ssh.rs
+++ b/boltconn/src/transport/ssh.rs
@@ -21,7 +21,8 @@ pub struct SshConfig {
     pub user: String,
     pub auth: SshAuthentication,
     // todo: check host pubkey
-    pub host_pubkey: Option<PublicKey>,
+    // (algo, pubkey)
+    pub host_pubkey: Option<(String, PublicKey)>,
 }
 
 impl PartialEq for SshConfig {

--- a/boltconn/src/transport/ssh.rs
+++ b/boltconn/src/transport/ssh.rs
@@ -1,0 +1,99 @@
+use crate::proxy::error::TransportError;
+use crate::proxy::NetworkAddr;
+use async_trait::async_trait;
+use russh::client::{connect_stream, Handle, Msg};
+use russh::keys::key::KeyPair;
+use russh::ChannelStream;
+use std::sync::atomic::AtomicU16;
+use std::sync::Arc;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+#[derive(Debug, Clone)]
+pub enum SshAuthentication {
+    Password(String),
+    PrivateKey(Arc<KeyPair>),
+}
+
+#[derive(Debug, Clone)]
+pub struct SshConfig {
+    internal_cfg: Arc<russh::client::Config>,
+    user: String,
+    auth: SshAuthentication,
+}
+
+impl SshConfig {
+    pub fn new(user: String, auth: SshAuthentication) -> Self {
+        Self {
+            internal_cfg: Arc::new(russh::client::Config::default()),
+            user,
+            auth,
+        }
+    }
+}
+
+struct Client {}
+
+#[async_trait]
+impl russh::client::Handler for Client {
+    type Error = TransportError;
+}
+pub struct SshTunnel {
+    client: Handle<Client>,
+    port_counter: AtomicU16,
+}
+
+impl SshTunnel {
+    pub fn new<S>(config: SshConfig, outbound: S) -> Result<Self, TransportError>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        Ok(Self {
+            client: connect_ssh_tunnel(&config, outbound)?,
+            port_counter: AtomicU16::new(1025),
+        })
+    }
+
+    pub async fn new_mapped_connection(
+        &self,
+        dst: NetworkAddr,
+    ) -> Result<ChannelStream<Msg>, TransportError> {
+        let dst_port = dst.port();
+        let channel = self
+            .client
+            .channel_open_direct_tcpip(
+                match dst {
+                    NetworkAddr::Raw(ip) => ip.ip().to_string(),
+                    NetworkAddr::DomainName { domain_name, .. } => domain_name,
+                },
+                dst_port as u32,
+                "127.0.0.1",
+                self.port_counter
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed) as u32,
+            )
+            .await
+            .map_err(TransportError::Ssh)?;
+        Ok(channel.into_stream())
+    }
+}
+
+async fn connect_ssh_tunnel<S>(
+    config: &SshConfig,
+    outbound: S,
+) -> Result<Handle<Client>, TransportError>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    let ssh_handler = Client {};
+    let mut handle = connect_stream(config.internal_cfg.clone(), outbound, ssh_handler).await?;
+    if !(match config.auth {
+        SshAuthentication::Password(ref p) => handle.authenticate_password(&config.user, p).await,
+        SshAuthentication::PrivateKey(ref k) => {
+            handle.authenticate_publickey(&config.user, k.clone()).await
+        }
+    }
+    .map_err(TransportError::Ssh)?)
+    {
+        return Err(TransportError::Ssh(russh::Error::NotAuthenticated));
+    }
+    Ok(handle)
+}

--- a/boltconn/src/transport/ssh.rs
+++ b/boltconn/src/transport/ssh.rs
@@ -20,6 +20,7 @@ pub struct SshConfig {
     pub server: NetworkAddr,
     pub user: String,
     pub auth: SshAuthentication,
+    // todo: check host pubkey
     pub host_pubkey: Option<PublicKey>,
 }
 

--- a/boltconn/src/transport/wireguard.rs
+++ b/boltconn/src/transport/wireguard.rs
@@ -3,7 +3,6 @@ use crate::common::MAX_PKT_SIZE;
 use crate::config::DnsPreference;
 use crate::network::dns::Dns;
 use crate::proxy::error::TransportError;
-use crate::proxy::error::WireGuardError::BoringTun;
 use crate::proxy::NetworkAddr;
 use crate::transport::AdapterOrSocket;
 use boringtun::noise::errors::WireGuardError;
@@ -111,8 +110,7 @@ impl WireguardTunnel {
             config.keepalive,
             13,
             None,
-        )
-        .map_err(|e| TransportError::WireGuard(BoringTun(e)))?;
+        );
         Ok(Self {
             tunnel: tokio::sync::Mutex::new(tunnel),
             inner: WireguardTunnelInner {


### PR DESCRIPTION
This PR enables SSH as a feasible proxy outbound. The configuration format is as below:
```yaml
<PROXY-NAME>:
        server: String, #<SERVER-DOMAIN-OR-IP>
        port: u16,
        user: String,
        password: Option<String>,
        private-key: Option<PathBuf>,
        key-passphrase: Option<String>,
        host-pubkey: Option<SingleOrVec<String>>,
```
Some rules worth noticing:
- When `private-key` is present, `password` field will be ignored.
- When `host-pubkey` is empty, the pubkey check will be skipped without warning.