### PR TITLE
fix: several WireGuard bugs

### DIFF
--- a/boltapi/src/rpc.rs
+++ b/boltapi/src/rpc.rs
@@ -57,6 +57,8 @@ pub trait ControlService {
 
     async fn get_master_conn_stat() -> Vec<MasterConnectionStatus>;
 
+    async fn stop_master_conn(id: String);
+
     async fn reload();
 
     // Streaming

--- a/boltapi/src/rpc.rs
+++ b/boltapi/src/rpc.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ConnectionSchema, GetGroupRespSchema, GetInterceptDataResp, HttpInterceptSchema, TrafficResp,
-    TunStatusSchema,
+    ConnectionSchema, GetGroupRespSchema, GetInterceptDataResp, HttpInterceptSchema,
+    MasterConnectionStatus, TrafficResp, TunStatusSchema,
 };
 
 pub const MAX_CODEC_FRAME_LENGTH: usize = 512 * 1024 * 1024;
@@ -54,6 +54,8 @@ pub trait ControlService {
     async fn set_conn_log_limit(limit: u32);
 
     async fn get_conn_log_limit() -> u32;
+
+    async fn get_master_conn_stat() -> Vec<MasterConnectionStatus>;
 
     async fn reload();
 

--- a/boltapi/src/schema.rs
+++ b/boltapi/src/schema.rs
@@ -118,3 +118,13 @@ pub struct TrafficResp {
 pub struct TunStatusSchema {
     pub enabled: bool,
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct MasterConnectionStatus {
+    pub name: String,
+    pub alive: bool,
+    pub last_active: u64,
+    pub last_handshake: u64,
+    pub hand_shake_is_expired: bool,
+}

--- a/boltconn/src/adapter/chain.rs
+++ b/boltconn/src/adapter/chain.rs
@@ -3,11 +3,11 @@ use crate::adapter::{
     UdpTransferType,
 };
 use async_trait::async_trait;
-use std::io;
 use std::sync::Arc;
 
 use crate::common::duplex_chan::DuplexChan;
 use crate::common::StreamOutboundTrait;
+use crate::proxy::error::TransportError;
 use crate::proxy::ConnAbortHandle;
 use crate::transport::UdpSocketAdapter;
 use tokio::task::JoinHandle;
@@ -32,7 +32,7 @@ impl ChainOutbound {
         mut inbound_tcp_container: Option<Connector>,
         mut inbound_udp_container: Option<AddrConnector>,
         abort_handle: ConnAbortHandle,
-    ) -> JoinHandle<io::Result<()>> {
+    ) -> JoinHandle<Result<(), TransportError>> {
         tokio::spawn(async move {
             let mut not_first_jump = false;
             let mut need_next_jump = true;
@@ -136,7 +136,7 @@ impl Outbound for ChainOutbound {
         &self,
         inbound: Connector,
         abort_handle: ConnAbortHandle,
-    ) -> JoinHandle<std::io::Result<()>> {
+    ) -> JoinHandle<Result<(), TransportError>> {
         self.clone().spawn(true, Some(inbound), None, abort_handle)
     }
 
@@ -146,9 +146,9 @@ impl Outbound for ChainOutbound {
         _tcp_outbound: Option<Box<dyn StreamOutboundTrait>>,
         _udp_outbound: Option<Box<dyn UdpSocketAdapter>>,
         _abort_handle: ConnAbortHandle,
-    ) -> io::Result<bool> {
+    ) -> Result<bool, TransportError> {
         tracing::error!("spawn_tcp_with_outbound() should not be called with ChainOutbound");
-        return Err(io::ErrorKind::InvalidData.into());
+        Err(TransportError::Internal("Invalid outbound"))
     }
 
     fn spawn_udp(
@@ -156,7 +156,7 @@ impl Outbound for ChainOutbound {
         inbound: AddrConnector,
         abort_handle: ConnAbortHandle,
         _tunnel_only: bool,
-    ) -> JoinHandle<io::Result<()>> {
+    ) -> JoinHandle<Result<(), TransportError>> {
         self.clone().spawn(false, None, Some(inbound), abort_handle)
     }
 
@@ -167,8 +167,8 @@ impl Outbound for ChainOutbound {
         _udp_outbound: Option<Box<dyn UdpSocketAdapter>>,
         _abort_handle: ConnAbortHandle,
         _tunnel_only: bool,
-    ) -> io::Result<bool> {
+    ) -> Result<bool, TransportError> {
         tracing::error!("spawn_udp_with_outbound() should not be called with ChainUdpOutbound");
-        return Err(io::ErrorKind::InvalidData.into());
+        Err(TransportError::Internal("Invalod outbound"))
     }
 }

--- a/boltconn/src/adapter/chain.rs
+++ b/boltconn/src/adapter/chain.rs
@@ -14,12 +14,14 @@ use tokio::task::JoinHandle;
 
 #[derive(Clone)]
 pub struct ChainOutbound {
+    name: String,
     chains: Vec<Arc<dyn Outbound>>,
 }
 
 impl ChainOutbound {
-    pub fn new(chains: Vec<Box<dyn Outbound>>) -> Self {
+    pub fn new(name: &str, chains: Vec<Box<dyn Outbound>>) -> Self {
         Self {
+            name: name.to_string(),
             chains: chains.into_iter().map(Arc::from).collect(),
         }
     }
@@ -122,6 +124,10 @@ impl ChainOutbound {
 
 #[async_trait]
 impl Outbound for ChainOutbound {
+    fn id(&self) -> String {
+        self.name.clone()
+    }
+
     fn outbound_type(&self) -> OutboundType {
         OutboundType::Chain
     }

--- a/boltconn/src/adapter/direct.rs
+++ b/boltconn/src/adapter/direct.rs
@@ -68,6 +68,10 @@ impl DirectOutbound {
 
 #[async_trait]
 impl Outbound for DirectOutbound {
+    fn id(&self) -> String {
+        "DIRECT".to_string()
+    }
+
     fn outbound_type(&self) -> OutboundType {
         OutboundType::Direct
     }

--- a/boltconn/src/adapter/direct.rs
+++ b/boltconn/src/adapter/direct.rs
@@ -127,7 +127,7 @@ impl UdpSocketAdapter for DirectUdpAdapter {
         let addr = match addr {
             NetworkAddr::Raw(s) => s,
             NetworkAddr::DomainName { domain_name, port } => {
-                let Some(ip) = self.1.genuine_lookup(domain_name.as_str()).await else {
+                let Ok(Some(ip)) = self.1.genuine_lookup(domain_name.as_str()).await else {
                     // drop
                     return Ok(());
                 };

--- a/boltconn/src/adapter/direct.rs
+++ b/boltconn/src/adapter/direct.rs
@@ -8,7 +8,6 @@ use crate::proxy::error::TransportError;
 use crate::proxy::{ConnAbortHandle, NetworkAddr};
 use crate::transport::UdpSocketAdapter;
 use async_trait::async_trait;
-use std::io;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::UdpSocket;
@@ -37,7 +36,11 @@ impl DirectOutbound {
         }
     }
 
-    async fn run_tcp(self, inbound: Connector, abort_handle: ConnAbortHandle) -> io::Result<()> {
+    async fn run_tcp(
+        self,
+        inbound: Connector,
+        abort_handle: ConnAbortHandle,
+    ) -> Result<(), TransportError> {
         let dst_addr = if let Some(dst) = self.resolved_dst {
             dst
         } else {
@@ -53,7 +56,7 @@ impl DirectOutbound {
         self,
         inbound: AddrConnector,
         abort_handle: ConnAbortHandle,
-    ) -> io::Result<()> {
+    ) -> Result<(), TransportError> {
         let outbound = Arc::new(Egress::new(&self.iface_name).udpv4_socket().await?);
         established_udp(
             self.id(),
@@ -81,7 +84,7 @@ impl Outbound for DirectOutbound {
         &self,
         inbound: Connector,
         abort_handle: ConnAbortHandle,
-    ) -> JoinHandle<io::Result<()>> {
+    ) -> JoinHandle<Result<(), TransportError>> {
         tokio::spawn(self.clone().run_tcp(inbound, abort_handle))
     }
 
@@ -91,9 +94,9 @@ impl Outbound for DirectOutbound {
         _tcp_outbound: Option<Box<dyn StreamOutboundTrait>>,
         _udp_outbound: Option<Box<dyn UdpSocketAdapter>>,
         _abort_handle: ConnAbortHandle,
-    ) -> io::Result<bool> {
+    ) -> Result<bool, TransportError> {
         tracing::error!("spawn_tcp_with_outbound() should not be called with DirectOutbound");
-        return Err(io::ErrorKind::InvalidData.into());
+        Err(TransportError::Internal("Invalid outbound"))
     }
 
     fn spawn_udp(
@@ -101,7 +104,7 @@ impl Outbound for DirectOutbound {
         inbound: AddrConnector,
         abort_handle: ConnAbortHandle,
         _tunnel_only: bool,
-    ) -> JoinHandle<io::Result<()>> {
+    ) -> JoinHandle<Result<(), TransportError>> {
         tokio::spawn(self.clone().run_udp(inbound, abort_handle))
     }
 
@@ -112,9 +115,9 @@ impl Outbound for DirectOutbound {
         _udp_outbound: Option<Box<dyn UdpSocketAdapter>>,
         _abort_handle: ConnAbortHandle,
         _tunnel_only: bool,
-    ) -> io::Result<bool> {
+    ) -> Result<bool, TransportError> {
         tracing::error!("spawn_udp_with_outbound() should not be called with DirectOutbound");
-        return Err(io::ErrorKind::InvalidData.into());
+        Err(TransportError::Internal("Invalid outbound"))
     }
 }
 

--- a/boltconn/src/adapter/direct.rs
+++ b/boltconn/src/adapter/direct.rs
@@ -45,7 +45,7 @@ impl DirectOutbound {
         };
         let outbound = Egress::new(&self.iface_name).tcp_stream(dst_addr).await?;
 
-        established_tcp(inbound, outbound, abort_handle).await;
+        established_tcp(self.id(), inbound, outbound, abort_handle).await;
         Ok(())
     }
 
@@ -56,6 +56,7 @@ impl DirectOutbound {
     ) -> io::Result<()> {
         let outbound = Arc::new(Egress::new(&self.iface_name).udpv4_socket().await?);
         established_udp(
+            self.id(),
             inbound,
             DirectUdpAdapter(outbound, self.dns.clone()),
             None,

--- a/boltconn/src/adapter/http.rs
+++ b/boltconn/src/adapter/http.rs
@@ -24,6 +24,7 @@ pub struct HttpConfig {
 
 #[derive(Clone)]
 pub struct HttpOutbound {
+    name: String,
     iface_name: String,
     dst: NetworkAddr,
     dns: Arc<Dns>,
@@ -31,8 +32,15 @@ pub struct HttpOutbound {
 }
 
 impl HttpOutbound {
-    pub fn new(iface_name: &str, dst: NetworkAddr, dns: Arc<Dns>, config: HttpConfig) -> Self {
+    pub fn new(
+        name: &str,
+        iface_name: &str,
+        dst: NetworkAddr,
+        dns: Arc<Dns>,
+        config: HttpConfig,
+    ) -> Self {
         Self {
+            name: name.to_string(),
             iface_name: iface_name.to_string(),
             dst,
             dns,
@@ -96,6 +104,10 @@ impl HttpOutbound {
 
 #[async_trait]
 impl Outbound for HttpOutbound {
+    fn id(&self) -> String {
+        self.name.clone()
+    }
+
     fn outbound_type(&self) -> OutboundType {
         OutboundType::Http
     }

--- a/boltconn/src/adapter/http.rs
+++ b/boltconn/src/adapter/http.rs
@@ -92,7 +92,7 @@ impl HttpOutbound {
             .map_err(|_| io_err("Parse response failed"))?;
         if let Some(200) = resp_struct.code {
             let tcp_stream = buf_reader.into_inner();
-            established_tcp(inbound, tcp_stream, abort_handle).await;
+            established_tcp(self.name, inbound, tcp_stream, abort_handle).await;
             Ok(())
         } else {
             Err(io_err(

--- a/boltconn/src/adapter/mod.rs
+++ b/boltconn/src/adapter/mod.rs
@@ -167,6 +167,10 @@ impl OutboundType {
 
 #[async_trait]
 pub trait Outbound: Send + Sync {
+    /// Get the globally unique id of the outbound to distinguish it
+    /// even from others with the same type.
+    fn id(&self) -> String;
+
     fn outbound_type(&self) -> OutboundType;
 
     /// Run with tokio::spawn.

--- a/boltconn/src/adapter/shadowsocks.rs
+++ b/boltconn/src/adapter/shadowsocks.rs
@@ -108,7 +108,7 @@ impl SSOutbound {
         let (target_addr, context, resolved_config) = self.create_internal(server_addr).await;
         let ss_stream =
             ProxyClientStream::from_stream(context, outbound, &resolved_config, target_addr);
-        established_tcp(inbound, ss_stream, abort_handle).await;
+        established_tcp(self.name, inbound, ss_stream, abort_handle).await;
         Ok(())
     }
 
@@ -123,6 +123,7 @@ impl SSOutbound {
         let (_, context, resolved_config) = self.create_internal(server_addr).await;
         let proxy_socket = ShadowsocksUdpAdapter::new(context, &resolved_config, adapter_or_socket);
         established_udp(
+            self.name,
             inbound,
             proxy_socket,
             if tunnel_only { Some(self.dst) } else { None },

--- a/boltconn/src/adapter/shadowsocks.rs
+++ b/boltconn/src/adapter/shadowsocks.rs
@@ -38,6 +38,7 @@ impl From<ShadowSocksConfig> for ServerConfig {
 
 #[derive(Clone)]
 pub struct SSOutbound {
+    name: String,
     iface_name: String,
     dst: NetworkAddr,
     dns: Arc<Dns>,
@@ -46,12 +47,14 @@ pub struct SSOutbound {
 
 impl SSOutbound {
     pub fn new(
+        name: &str,
         iface_name: &str,
         dst: NetworkAddr,
         dns: Arc<Dns>,
         config: ShadowSocksConfig,
     ) -> Self {
         Self {
+            name: name.to_string(),
             iface_name: iface_name.to_string(),
             dst,
             dns,
@@ -132,6 +135,10 @@ impl SSOutbound {
 
 #[async_trait]
 impl Outbound for SSOutbound {
+    fn id(&self) -> String {
+        self.name.clone()
+    }
+
     fn outbound_type(&self) -> OutboundType {
         OutboundType::Shadowsocks
     }

--- a/boltconn/src/adapter/socks5.rs
+++ b/boltconn/src/adapter/socks5.rs
@@ -91,7 +91,7 @@ impl Socks5Outbound {
             .request(Socks5Command::TCPConnect, target)
             .await
             .map_err(as_io_err)?;
-        established_tcp(inbound, socks_stream, abort_handle).await;
+        established_tcp(self.name, inbound, socks_stream, abort_handle).await;
         Ok(())
     }
 
@@ -126,6 +126,7 @@ impl Socks5Outbound {
             .unwrap();
         out_sock.connect(bound_addr).await?;
         established_udp(
+            self.name,
             inbound,
             Socks5UdpAdapter(out_sock),
             if tunnel_only { Some(self.dst) } else { None },

--- a/boltconn/src/adapter/socks5.rs
+++ b/boltconn/src/adapter/socks5.rs
@@ -41,6 +41,7 @@ impl Socks5Config {
 
 #[derive(Clone)]
 pub struct Socks5Outbound {
+    name: String,
     iface_name: String,
     dst: NetworkAddr,
     dns: Arc<Dns>,
@@ -48,8 +49,15 @@ pub struct Socks5Outbound {
 }
 
 impl Socks5Outbound {
-    pub fn new(iface_name: &str, dst: NetworkAddr, dns: Arc<Dns>, config: Socks5Config) -> Self {
+    pub fn new(
+        name: &str,
+        iface_name: &str,
+        dst: NetworkAddr,
+        dns: Arc<Dns>,
+        config: Socks5Config,
+    ) -> Self {
         Self {
+            name: name.to_string(),
             iface_name: iface_name.to_string(),
             dst,
             dns,
@@ -130,6 +138,10 @@ impl Socks5Outbound {
 
 #[async_trait]
 impl Outbound for Socks5Outbound {
+    fn id(&self) -> String {
+        self.name.clone()
+    }
+
     fn outbound_type(&self) -> OutboundType {
         OutboundType::Socks5
     }

--- a/boltconn/src/adapter/ssh.rs
+++ b/boltconn/src/adapter/ssh.rs
@@ -19,6 +19,7 @@ use tokio::task::JoinHandle;
 
 #[derive(Clone)]
 pub struct SshOutboundHandle {
+    name: String,
     iface_name: String,
     dst: NetworkAddr,
     dns: Arc<Dns>,
@@ -28,6 +29,7 @@ pub struct SshOutboundHandle {
 
 impl SshOutboundHandle {
     pub fn new(
+        name: &str,
         iface_name: &str,
         dst: NetworkAddr,
         dns: Arc<Dns>,
@@ -35,6 +37,7 @@ impl SshOutboundHandle {
         manager: Arc<SshManager>,
     ) -> Self {
         Self {
+            name: name.to_string(),
             iface_name: iface_name.to_string(),
             dst,
             dns,
@@ -82,6 +85,10 @@ impl SshOutboundHandle {
 
 #[async_trait]
 impl Outbound for SshOutboundHandle {
+    fn id(&self) -> String {
+        self.name.clone()
+    }
+
     fn outbound_type(&self) -> OutboundType {
         OutboundType::Ssh
     }

--- a/boltconn/src/adapter/ssh.rs
+++ b/boltconn/src/adapter/ssh.rs
@@ -78,7 +78,7 @@ impl SshOutboundHandle {
             }
         };
         let channel = master_conn.new_mapped_connection(self.dst.clone()).await?;
-        established_tcp(inbound, channel, abort_handle).await;
+        established_tcp(self.name, inbound, channel, abort_handle).await;
         Ok(())
     }
 }

--- a/boltconn/src/adapter/trojan.rs
+++ b/boltconn/src/adapter/trojan.rs
@@ -27,6 +27,7 @@ use tokio_tungstenite::client_async;
 
 #[derive(Clone)]
 pub struct TrojanOutbound {
+    name: String,
     iface_name: String,
     dst: NetworkAddr,
     dns: Arc<Dns>,
@@ -34,8 +35,15 @@ pub struct TrojanOutbound {
 }
 
 impl TrojanOutbound {
-    pub fn new(iface_name: &str, dst: NetworkAddr, dns: Arc<Dns>, config: TrojanConfig) -> Self {
+    pub fn new(
+        name: &str,
+        iface_name: &str,
+        dst: NetworkAddr,
+        dns: Arc<Dns>,
+        config: TrojanConfig,
+    ) -> Self {
         Self {
+            name: name.to_string(),
             iface_name: iface_name.to_string(),
             dst,
             dns,
@@ -173,6 +181,10 @@ impl TrojanOutbound {
 
 #[async_trait]
 impl Outbound for TrojanOutbound {
+    fn id(&self) -> String {
+        self.name.clone()
+    }
+
     fn outbound_type(&self) -> OutboundType {
         OutboundType::Trojan
     }

--- a/boltconn/src/adapter/trojan.rs
+++ b/boltconn/src/adapter/trojan.rs
@@ -69,11 +69,11 @@ impl TrojanOutbound {
                 .map_err(|e| io_err(e.to_string().as_str()))?;
             self.first_packet(first_packet, TrojanCmd::Connect, &mut stream)
                 .await?;
-            established_tcp(inbound, stream, abort_handle).await;
+            established_tcp(self.name, inbound, stream, abort_handle).await;
         } else {
             self.first_packet(first_packet, TrojanCmd::Connect, &mut stream)
                 .await?;
-            established_tcp(inbound, stream, abort_handle).await;
+            established_tcp(self.name, inbound, stream, abort_handle).await;
         }
         Ok(())
     }
@@ -103,6 +103,7 @@ impl TrojanOutbound {
                 socket: Arc::new(udp_socket),
             };
             established_udp(
+                self.name,
                 inbound,
                 adapter,
                 if tunnel_only { Some(self.dst) } else { None },
@@ -117,6 +118,7 @@ impl TrojanOutbound {
                 socket: Arc::new(udp_socket),
             };
             established_udp(
+                self.name,
                 inbound,
                 adapter,
                 if tunnel_only { Some(self.dst) } else { None },

--- a/boltconn/src/adapter/wireguard.rs
+++ b/boltconn/src/adapter/wireguard.rs
@@ -407,10 +407,10 @@ impl WireguardHandle {
         let dst = match self.dst {
             NetworkAddr::Raw(s) => s,
             NetworkAddr::DomainName { domain_name, port } => SocketAddr::new(
-                smol_dns
-                    .genuine_lookup(domain_name.as_str())
-                    .await
-                    .ok_or::<io::Error>(ErrorKind::AddrNotAvailable.into())?,
+                match smol_dns.genuine_lookup(domain_name.as_str()).await {
+                    Ok(Some(addr)) => addr,
+                    _ => return Err(ErrorKind::AddrNotAvailable.into()),
+                },
                 port,
             ),
         };

--- a/boltconn/src/adapter/wireguard.rs
+++ b/boltconn/src/adapter/wireguard.rs
@@ -40,6 +40,7 @@ pub struct Endpoint {
 
 impl Endpoint {
     pub async fn new(
+        name: &str,
         outbound: AdapterOrSocket,
         config: &WireguardConfig,
         endpoint_resolver: Arc<Dns>,
@@ -80,7 +81,13 @@ impl Endpoint {
                     resolver,
                     config.dns_preference,
                 ));
-                Mutex::new(SmolStack::new(iface, device, dns, Duration::from_secs(120)))
+                Mutex::new(SmolStack::new(
+                    name,
+                    iface,
+                    device,
+                    dns,
+                    Duration::from_secs(120),
+                ))
             })
         };
 
@@ -265,6 +272,7 @@ impl WireguardManager {
 
     pub async fn get_wg_conn(
         &self,
+        name: &str,
         config: &WireguardConfig,
         adapter: Option<AdapterOrSocket>,
         ret_tx: tokio::sync::oneshot::Sender<bool>,
@@ -310,6 +318,7 @@ impl WireguardManager {
                     }
                 };
                 let ep = Endpoint::new(
+                    name,
                     outbound,
                     config,
                     self.endpoint_resolver.clone(),
@@ -385,7 +394,7 @@ impl WireguardHandle {
         ret_tx: tokio::sync::oneshot::Sender<bool>,
     ) -> io::Result<Arc<Endpoint>> {
         self.manager
-            .get_wg_conn(&self.config, adapter, ret_tx)
+            .get_wg_conn(&self.name, &self.config, adapter, ret_tx)
             .await
             .map_err(|e| io_err(format!("{}", e).as_str()))
     }

--- a/boltconn/src/adapter/wireguard.rs
+++ b/boltconn/src/adapter/wireguard.rs
@@ -328,6 +328,7 @@ impl WireguardManager {
 
 #[derive(Clone)]
 pub struct WireguardHandle {
+    name: String,
     src: SocketAddr,
     dst: NetworkAddr,
     config: Arc<WireguardConfig>,
@@ -337,6 +338,7 @@ pub struct WireguardHandle {
 
 impl WireguardHandle {
     pub fn new(
+        name: &str,
         src: SocketAddr,
         dst: NetworkAddr,
         config: WireguardConfig,
@@ -344,6 +346,7 @@ impl WireguardHandle {
         dns_config: Arc<ResolverConfig>,
     ) -> Self {
         Self {
+            name: name.to_string(),
             src,
             dst,
             config: Arc::new(config),
@@ -403,6 +406,10 @@ impl WireguardHandle {
 
 #[async_trait]
 impl Outbound for WireguardHandle {
+    fn id(&self) -> String {
+        self.name.clone()
+    }
+
     fn outbound_type(&self) -> OutboundType {
         OutboundType::Wireguard
     }

--- a/boltconn/src/adapter/wireguard.rs
+++ b/boltconn/src/adapter/wireguard.rs
@@ -78,6 +78,7 @@ impl Endpoint {
                     )
                 };
                 let dns = Arc::new(GenericDns::new_with_resolver(
+                    name,
                     resolver,
                     config.dns_preference,
                 ));

--- a/boltconn/src/app.rs
+++ b/boltconn/src/app.rs
@@ -447,6 +447,7 @@ async fn initialize_dns(
                 .await
                 .map_err(|e| anyhow!("Parse nameserver policy failed: {e}"))?;
         Arc::new(Dns::with_config(
+            "default",
             outbound_iface,
             config.preference,
             &config.hosts,

--- a/boltconn/src/cli/mod.rs
+++ b/boltconn/src/cli/mod.rs
@@ -174,10 +174,17 @@ pub(crate) enum LogsLimitOptions {
     Get,
 }
 
-#[derive(Debug, Clone, Copy, Subcommand)]
+#[derive(Clone, Debug, Args)]
+pub(crate) struct WgOptions {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Subcommand)]
 pub(crate) enum MasterConnOptions {
     /// Show the WireGuard master connections
-    Wg,
+    ListWg,
+    /// Stop a WireGuard connection
+    StopWg(WgOptions),
 }
 
 #[derive(Debug, Subcommand)]
@@ -387,7 +394,8 @@ pub(crate) async fn controller_main(args: ProgramArgs) -> ! {
         },
         #[cfg(feature = "internal-test")]
         SubCommand::MasterConn(opt) => match opt {
-            MasterConnOptions::Wg => requester.master_conn_stats().await,
+            MasterConnOptions::ListWg => requester.master_conn_stats().await,
+            MasterConnOptions::StopWg(opt) => requester.stop_master_conn(opt.name).await,
         },
         SubCommand::Start(_)
         | SubCommand::Generate(_)

--- a/boltconn/src/cli/mod.rs
+++ b/boltconn/src/cli/mod.rs
@@ -174,6 +174,12 @@ pub(crate) enum LogsLimitOptions {
     Get,
 }
 
+#[derive(Debug, Clone, Copy, Subcommand)]
+pub(crate) enum MasterConnOptions {
+    /// Show the WireGuard master connections
+    Wg,
+}
+
 #[derive(Debug, Subcommand)]
 pub(crate) enum SubCommand {
     /// Start the main program
@@ -207,6 +213,10 @@ pub(crate) enum SubCommand {
     /// Generate necessary files before the first run
     #[command(subcommand)]
     Generate(GenerateOptions),
+    #[cfg(feature = "internal-test")]
+    #[clap(hide = true)]
+    #[command(subcommand)]
+    MasterConn(MasterConnOptions),
     #[cfg(feature = "internal-test")]
     #[clap(hide = true)]
     Internal,
@@ -375,6 +385,9 @@ pub(crate) async fn controller_main(args: ProgramArgs) -> ! {
             DnsOptions::Lookup { domain_name } => requester.real_lookup(domain_name).await,
             DnsOptions::Mapping { fake_ip } => requester.fake_ip_to_real(fake_ip).await,
         },
+        SubCommand::MasterConn(opt) => match opt {
+            MasterConnOptions::Wg => requester.master_conn_stats().await,
+        },
         SubCommand::Start(_)
         | SubCommand::Generate(_)
         | SubCommand::Clean
@@ -383,9 +396,7 @@ pub(crate) async fn controller_main(args: ProgramArgs) -> ! {
             unreachable!()
         }
         #[cfg(feature = "internal-test")]
-        SubCommand::Internal => {
-            unreachable!()
-        }
+        SubCommand::Internal => internal_code(requester).await,
     };
     match result {
         Ok(_) => exit(0),
@@ -394,4 +405,13 @@ pub(crate) async fn controller_main(args: ProgramArgs) -> ! {
             exit(-1)
         }
     }
+}
+
+#[cfg(feature = "internal-test")]
+use crate::cli::request::Requester;
+/// This function is a shortcut for testing things conveniently. Only for development use.
+#[cfg(feature = "internal-test")]
+async fn internal_code(_requester: Requester) -> anyhow::Result<()> {
+    println!("This option is not for end-user.");
+    Ok(())
 }

--- a/boltconn/src/cli/mod.rs
+++ b/boltconn/src/cli/mod.rs
@@ -385,6 +385,7 @@ pub(crate) async fn controller_main(args: ProgramArgs) -> ! {
             DnsOptions::Lookup { domain_name } => requester.real_lookup(domain_name).await,
             DnsOptions::Mapping { fake_ip } => requester.fake_ip_to_real(fake_ip).await,
         },
+        #[cfg(feature = "internal-test")]
         SubCommand::MasterConn(opt) => match opt {
             MasterConnOptions::Wg => requester.master_conn_stats().await,
         },

--- a/boltconn/src/cli/request.rs
+++ b/boltconn/src/cli/request.rs
@@ -327,6 +327,18 @@ impl Requester {
             }
         }
     }
+
+    pub async fn stop_master_conn(&self, id: String) -> Result<()> {
+        match &self.inner {
+            Inner::Web(_) => Err(anyhow::anyhow!(
+                "stop master conn: Not supported by RESTful API"
+            )),
+            Inner::Uds(c) => {
+                c.stop_master_conn(id).await?;
+                Ok(())
+            }
+        }
+    }
 }
 
 fn pretty_size(data: u64) -> String {

--- a/boltconn/src/cli/request_uds.rs
+++ b/boltconn/src/cli/request_uds.rs
@@ -3,7 +3,7 @@ use boltapi::multiplex::rpc_multiplex_twoway;
 use boltapi::rpc::{ClientStreamServiceRequest, ClientStreamServiceResponse, ControlServiceClient};
 use boltapi::{
     ConnectionSchema, GetGroupRespSchema, GetInterceptDataResp, HttpInterceptSchema,
-    TunStatusSchema,
+    MasterConnectionStatus, TunStatusSchema,
 };
 use tarpc::context::Context;
 use tarpc::tokio_util::codec::LengthDelimitedCodec;
@@ -170,5 +170,9 @@ impl UdsConnector {
 
     pub async fn reload_config(&self) -> Result<()> {
         Ok(self.client.reload(Context::current()).await?)
+    }
+
+    pub async fn get_master_conn_stat(&self) -> Result<Vec<MasterConnectionStatus>> {
+        Ok(self.client.get_master_conn_stat(Context::current()).await?)
     }
 }

--- a/boltconn/src/cli/request_uds.rs
+++ b/boltconn/src/cli/request_uds.rs
@@ -175,4 +175,8 @@ impl UdsConnector {
     pub async fn get_master_conn_stat(&self) -> Result<Vec<MasterConnectionStatus>> {
         Ok(self.client.get_master_conn_stat(Context::current()).await?)
     }
+
+    pub async fn stop_master_conn(&self, id: String) -> Result<()> {
+        Ok(self.client.stop_master_conn(Context::current(), id).await?)
+    }
 }

--- a/boltconn/src/dispatch/action.rs
+++ b/boltconn/src/dispatch/action.rs
@@ -26,7 +26,7 @@ impl LocalResolve {
     pub async fn resolve_to(&self, info: &mut ConnInfo) {
         if info.resolved_dst.is_none() {
             if let NetworkAddr::DomainName { domain_name, port } = &info.dst {
-                if let Some(addr) = self.dns.genuine_lookup(domain_name).await {
+                if let Ok(Some(addr)) = self.dns.genuine_lookup(domain_name).await {
                     info.resolved_dst = Some(SocketAddr::new(addr, *port));
                 }
             }

--- a/boltconn/src/external/controller.rs
+++ b/boltconn/src/external/controller.rs
@@ -394,6 +394,10 @@ impl Controller {
         self.dispatcher.get_wg_mgr().debug_internal_state().await
     }
 
+    pub async fn stop_master_conn(&self, id: String) {
+        self.dispatcher.get_wg_mgr().stop_master_conn(&id).await;
+    }
+
     pub async fn real_lookup(&self, domain_name: String) -> Option<String> {
         match self.dns.genuine_lookup(domain_name.as_str()).await {
             Ok(Some(ip)) => Some(ip.to_string()),

--- a/boltconn/src/external/controller.rs
+++ b/boltconn/src/external/controller.rs
@@ -395,10 +395,10 @@ impl Controller {
     }
 
     pub async fn real_lookup(&self, domain_name: String) -> Option<String> {
-        self.dns
-            .genuine_lookup(domain_name.as_str())
-            .await
-            .map(|ip| ip.to_string())
+        match self.dns.genuine_lookup(domain_name.as_str()).await {
+            Ok(Some(ip)) => Some(ip.to_string()),
+            _ => None,
+        }
     }
 
     pub fn fake_ip_to_real(&self, fake_ip: String) -> Option<String> {

--- a/boltconn/src/external/controller.rs
+++ b/boltconn/src/external/controller.rs
@@ -9,7 +9,8 @@ use crate::proxy::{
 };
 use boltapi::{
     ConnectionSchema, GetGroupRespSchema, GetInterceptDataResp, GetInterceptRangeReq,
-    HttpInterceptSchema, ProcessSchema, ProxyData, SessionSchema, TrafficResp, TunStatusSchema,
+    HttpInterceptSchema, MasterConnectionStatus, ProcessSchema, ProxyData, SessionSchema,
+    TrafficResp, TunStatusSchema,
 };
 use std::collections::HashSet;
 use std::io::Write;
@@ -387,6 +388,10 @@ impl Controller {
 
     pub fn get_conn_log_limit(&self) -> u32 {
         self.stat_center.get_conn_log_limit()
+    }
+
+    pub async fn get_master_conn_stat(&self) -> Vec<MasterConnectionStatus> {
+        self.dispatcher.get_wg_mgr().debug_internal_state().await
     }
 
     pub async fn real_lookup(&self, domain_name: String) -> Option<String> {

--- a/boltconn/src/external/uds_controller.rs
+++ b/boltconn/src/external/uds_controller.rs
@@ -5,7 +5,7 @@ use boltapi::multiplex::rpc_multiplex_twoway;
 use boltapi::rpc::{ClientStreamServiceClient, ControlService};
 use boltapi::{
     ConnectionSchema, GetGroupRespSchema, GetInterceptDataResp, GetInterceptRangeReq,
-    HttpInterceptSchema, TrafficResp, TunStatusSchema,
+    HttpInterceptSchema, MasterConnectionStatus, TrafficResp, TunStatusSchema,
 };
 use std::io;
 use std::sync::Arc;
@@ -341,6 +341,10 @@ impl ControlService for UdsRpcServer {
 
     async fn get_conn_log_limit(self, _ctx: Context) -> u32 {
         self.controller.get_conn_log_limit()
+    }
+
+    async fn get_master_conn_stat(self, _ctx: Context) -> Vec<MasterConnectionStatus> {
+        self.controller.get_master_conn_stat().await
     }
 
     async fn reload(self, _ctx: Context) {

--- a/boltconn/src/external/uds_controller.rs
+++ b/boltconn/src/external/uds_controller.rs
@@ -347,6 +347,10 @@ impl ControlService for UdsRpcServer {
         self.controller.get_master_conn_stat().await
     }
 
+    async fn stop_master_conn(self, _ctx: Context, id: String) {
+        self.controller.stop_master_conn(id).await
+    }
+
     async fn reload(self, _ctx: Context) {
         self.controller.reload().await
     }

--- a/boltconn/src/main.rs
+++ b/boltconn/src/main.rs
@@ -53,8 +53,6 @@ fn main() -> ExitCode {
     let args: ProgramArgs = ProgramArgs::parse();
     let cmds = match args.cmd {
         SubCommand::Start(sub) => sub,
-        #[cfg(feature = "internal-test")]
-        SubCommand::Internal => return internal_code(),
         _ => rt.block_on(cli::controller_main(args)),
     };
     if !is_root() {
@@ -136,11 +134,4 @@ pub(crate) fn process_path(cmds: &StartOptions) -> Result<(PathBuf, PathBuf, Pat
         return Err(ExitCode::FAILURE);
     }
     Ok((config_path, data_path, cert_path))
-}
-
-/// This function is a shortcut for testing things conveniently. Only for development use.
-#[cfg(feature = "internal-test")]
-fn internal_code() -> ExitCode {
-    println!("This option is not for end-user.");
-    ExitCode::SUCCESS
 }

--- a/boltconn/src/proxy/dispatcher.rs
+++ b/boltconn/src/proxy/dispatcher.rs
@@ -86,6 +86,7 @@ impl Dispatcher {
 
     pub(super) fn build_normal_outbound(
         &self,
+        proxy_name: &str,
         iface_name: &str,
         proxy_config: &ProxyImpl,
         src_addr: SocketAddr,
@@ -104,6 +105,7 @@ impl Dispatcher {
             ),
             ProxyImpl::Http(cfg) => (
                 Box::new(HttpOutbound::new(
+                    proxy_name,
                     iface_name,
                     dst_addr.clone(),
                     self.dns.clone(),
@@ -113,6 +115,7 @@ impl Dispatcher {
             ),
             ProxyImpl::Socks5(cfg) => (
                 Box::new(Socks5Outbound::new(
+                    proxy_name,
                     iface_name,
                     dst_addr.clone(),
                     self.dns.clone(),
@@ -122,6 +125,7 @@ impl Dispatcher {
             ),
             ProxyImpl::Shadowsocks(cfg) => (
                 Box::new(SSOutbound::new(
+                    proxy_name,
                     iface_name,
                     dst_addr.clone(),
                     self.dns.clone(),
@@ -131,6 +135,7 @@ impl Dispatcher {
             ),
             ProxyImpl::Trojan(cfg) => (
                 Box::new(TrojanOutbound::new(
+                    proxy_name,
                     iface_name,
                     dst_addr.clone(),
                     self.dns.clone(),
@@ -140,6 +145,7 @@ impl Dispatcher {
             ),
             ProxyImpl::Wireguard(cfg) => (
                 Box::new(WireguardHandle::new(
+                    proxy_name,
                     src_addr,
                     dst_addr.clone(),
                     cfg.clone(),
@@ -150,6 +156,7 @@ impl Dispatcher {
             ),
             ProxyImpl::Ssh(cfg) => (
                 Box::new(SshOutboundHandle::new(
+                    proxy_name,
                     iface_name,
                     dst_addr.clone(),
                     self.dns.clone(),
@@ -168,6 +175,7 @@ impl Dispatcher {
 
     pub(super) fn create_chain(
         &self,
+        chain_name: &str,
         vec: &[GeneralProxy],
         src_addr: SocketAddr,
         dst_addr: &NetworkAddr,
@@ -176,8 +184,8 @@ impl Dispatcher {
         let impls: Vec<_> = vec
             .iter()
             .map(|n| match n {
-                GeneralProxy::Single(p) => p.get_impl(),
-                GeneralProxy::Group(g) => g.get_proxy().get_impl(),
+                GeneralProxy::Single(p) => (p.get_name(), p.get_impl()),
+                GeneralProxy::Group(g) => (g.get_name(), g.get_proxy().get_impl()),
             })
             .collect();
         let mut res = vec![];
@@ -187,7 +195,7 @@ impl Dispatcher {
         // if A->B->C, then vec is [C, B, A]
         dst_addrs.push(dst_addr.clone());
         for idx in 1..vec.len() {
-            let proxy_impl = impls.get(idx - 1).unwrap().as_ref();
+            let proxy_impl = impls.get(idx - 1).unwrap().1.as_ref();
             if let Some(dst) = proxy_impl.server_addr() {
                 dst_addrs.push(dst);
             } else {
@@ -197,16 +205,18 @@ impl Dispatcher {
         }
 
         for idx in 0..vec.len() {
+            let proxy = impls.get(idx).unwrap();
             let (outbounding, _) = self.build_normal_outbound(
+                &proxy.0,
                 iface_name,
-                impls.get(idx).unwrap().as_ref(),
+                &proxy.1,
                 src_addr,
                 dst_addrs.get(idx).unwrap(),
                 None,
             )?;
             res.push(outbounding);
         }
-        Ok(ChainOutbound::new(res))
+        Ok(ChainOutbound::new(chain_name, res))
     }
 
     pub async fn submit_tcp<S: StreamOutboundTrait>(
@@ -238,7 +248,7 @@ impl Dispatcher {
             match proxy_config.as_ref() {
                 ProxyImpl::Chain(vec) => (
                     Box::new(
-                        self.create_chain(vec, src_addr, &dst_addr, iface_name)
+                        self.create_chain(&proxy_name, vec, src_addr, &dst_addr, iface_name)
                             .map_err(|_| DispatchError::BadChain)?,
                     ),
                     OutboundType::Chain,
@@ -252,6 +262,7 @@ impl Dispatcher {
                 }
                 _ => self
                     .build_normal_outbound(
+                        &proxy_name,
                         iface_name,
                         proxy_config.as_ref(),
                         src_addr,
@@ -405,7 +416,7 @@ impl Dispatcher {
             match proxy_config.as_ref() {
                 ProxyImpl::Chain(vec) => (
                     Box::new(
-                        self.create_chain(vec, src_addr, &dst_addr, iface_name)
+                        self.create_chain(&proxy_name, vec, src_addr, &dst_addr, iface_name)
                             .map_err(|_| DispatchError::Reject)?,
                     ),
                     OutboundType::Chain,
@@ -413,6 +424,7 @@ impl Dispatcher {
                 ProxyImpl::BlackHole => return Err(DispatchError::BlackHole),
                 _ => self
                     .build_normal_outbound(
+                        &proxy_name,
                         iface_name,
                         proxy_config.as_ref(),
                         src_addr,

--- a/boltconn/src/proxy/dispatcher.rs
+++ b/boltconn/src/proxy/dispatcher.rs
@@ -80,6 +80,10 @@ impl Dispatcher {
         self.modifier.store(Arc::new(closure));
     }
 
+    pub fn get_wg_mgr(&self) -> Arc<WireguardManager> {
+        self.wireguard_mgr.clone()
+    }
+
     pub(super) fn get_iface_name(&self) -> String {
         self.iface_name.clone()
     }

--- a/boltconn/src/proxy/dispatcher.rs
+++ b/boltconn/src/proxy/dispatcher.rs
@@ -185,7 +185,10 @@ impl Dispatcher {
             .iter()
             .map(|n| match n {
                 GeneralProxy::Single(p) => (p.get_name(), p.get_impl()),
-                GeneralProxy::Group(g) => (g.get_name(), g.get_proxy().get_impl()),
+                GeneralProxy::Group(g) => {
+                    let proxy = g.get_proxy();
+                    (proxy.get_name(), proxy.get_impl())
+                }
             })
             .collect();
         let mut res = vec![];

--- a/boltconn/src/proxy/error.rs
+++ b/boltconn/src/proxy/error.rs
@@ -44,6 +44,8 @@ pub enum TransportError {
     WireGuard(&'static str),
     #[error("SSH error: {0}")]
     Ssh(#[from] russh::Error),
+    #[error("Timeout: {0}")]
+    Timeout(&'static str),
 }
 
 #[derive(Error, Debug)]
@@ -52,6 +54,8 @@ pub enum DnsError {
     MissingBootstrap(String),
     #[error("Failed to resolve dns server: {0}")]
     ResolveServer(String),
+    #[error("Failed to resolve domain name: {0}")]
+    ResolveDomain(String),
 }
 
 #[derive(Error, Debug)]

--- a/boltconn/src/proxy/mod.rs
+++ b/boltconn/src/proxy/mod.rs
@@ -101,6 +101,7 @@ pub async fn latency_test(
     let creator: Box<dyn Outbound> = match proxy.get_impl().as_ref() {
         ProxyImpl::Chain(vec) => {
             match dispatcher.create_chain(
+                &proxy.get_name(),
                 vec,
                 get_random_local_addr(&dst_addr, rng.gen_range(32768..65535)),
                 &dst_addr,
@@ -115,6 +116,7 @@ pub async fn latency_test(
         }
         proxy_config => {
             let creator = match dispatcher.build_normal_outbound(
+                &proxy.get_name(),
                 iface.as_str(),
                 proxy_config,
                 get_random_local_addr(&dst_addr, rng.gen_range(32768..65535)),

--- a/boltconn/src/proxy/tun_udp_inbound.rs
+++ b/boltconn/src/proxy/tun_udp_inbound.rs
@@ -109,7 +109,7 @@ impl TunUdpInbound {
                 // hijack dns
                 if let Ok(answer) = self.dns.respond_to_query(payload.as_ref()) {
                     let raw_data = create_raw_udp_pkt(answer.as_ref(), dst, src);
-                    if let Err(e) = self.tun_tx.send_async(raw_data.freeze()).await {
+                    if self.tun_tx.send_async(raw_data.freeze()).await.is_err() {
                         tracing::error!("TUN back tx closed");
                     }
                 }

--- a/boltconn/src/proxy/tun_udp_inbound.rs
+++ b/boltconn/src/proxy/tun_udp_inbound.rs
@@ -109,7 +109,9 @@ impl TunUdpInbound {
                 // hijack dns
                 if let Ok(answer) = self.dns.respond_to_query(payload.as_ref()) {
                     let raw_data = create_raw_udp_pkt(answer.as_ref(), dst, src);
-                    let _ = self.tun_tx.send(raw_data.freeze());
+                    if let Err(e) = self.tun_tx.send_async(raw_data.freeze()).await {
+                        tracing::error!("TUN back tx closed");
+                    }
                 }
             } else {
                 // retry once

--- a/boltconn/src/transport/smol.rs
+++ b/boltconn/src/transport/smol.rs
@@ -143,7 +143,9 @@ impl TcpConnTask {
         // notify smol when new message comes
         tokio::spawn(async move {
             while let Some(buf) = back_rx.recv().await {
-                let _ = tx.send_async(buf).await;
+                if tx.send_async(buf).await.is_err() {
+                    return;
+                }
                 notify.notify_one();
             }
         });
@@ -307,7 +309,9 @@ impl UdpConnTask {
                         .await
                         .map(|ip| SocketAddr::new(ip, port)),
                 } {
-                    let _ = tx.send_async((buf, dst)).await;
+                    if tx.send_async((buf, dst)).await.is_err() {
+                        return;
+                    }
                     notify.notify_one();
                 }
             }

--- a/boltconn/src/transport/smol.rs
+++ b/boltconn/src/transport/smol.rs
@@ -464,30 +464,20 @@ impl SmolStack {
         abort_handle: ConnAbortHandle,
         notify: Arc<Notify>,
     ) -> io::Result<()> {
-        if local_addr.port() == 0 {
-            for _ in 0..10 {
-                let port = rand::thread_rng().gen_range(32768..65534);
-                match self.tcp_conn.entry(port) {
-                    Entry::Occupied(_) => continue,
-                    Entry::Vacant(e) => {
-                        let handle = Self::open_tcp_inner(
-                            &mut self.iface,
-                            &mut self.socket_set,
-                            self.ip_addr
-                                .matched_if_addr(remote_addr.ip())
-                                .ok_or::<io::Error>(ErrorKind::AddrNotAvailable.into())?,
-                            port,
-                            remote_addr,
-                        )?;
-                        e.insert(TcpConnTask::new(connector, handle, abort_handle, notify));
-                        return Ok(());
+        let choose_a_local_port = local_addr.port() == 0;
+        for _ in 0..10 {
+            let local_port = if choose_a_local_port {
+                rand::thread_rng().gen_range(32768..65534)
+            } else {
+                local_addr.port()
+            };
+            return match self.tcp_conn.entry(local_port) {
+                Entry::Occupied(_) => {
+                    if choose_a_local_port {
+                        continue;
                     }
+                    Err(ErrorKind::AddrInUse.into())
                 }
-            }
-            Err(ErrorKind::AddrNotAvailable.into())
-        } else {
-            match self.tcp_conn.entry(local_addr.port()) {
-                Entry::Occupied(_) => Err(ErrorKind::AddrInUse.into()),
                 Entry::Vacant(e) => {
                     let handle = Self::open_tcp_inner(
                         &mut self.iface,
@@ -501,8 +491,9 @@ impl SmolStack {
                     e.insert(TcpConnTask::new(connector, handle, abort_handle, notify));
                     Ok(())
                 }
-            }
+            };
         }
+        Err(ErrorKind::AddrNotAvailable.into())
     }
 
     fn open_tcp_inner(
@@ -555,36 +546,21 @@ impl SmolStack {
         buffer_packet_cnt: usize,
     ) -> io::Result<()> {
         // todo: IPv6 support when local_addr is a V4 address
-        if local_addr.port() == 0 {
-            for _ in 0..10 {
-                let port = rand::thread_rng().gen_range(32768..65534);
-                match self.udp_conn.entry(port) {
-                    Entry::Occupied(_) => continue,
-                    Entry::Vacant(e) => {
-                        let handle = Self::open_udp_inner(
-                            &mut self.socket_set,
-                            self.ip_addr
-                                .matched_if_addr(local_addr.ip())
-                                .ok_or::<io::Error>(ErrorKind::AddrNotAvailable.into())?,
-                            port,
-                            buffer_packet_cnt,
-                        )?;
-                        e.insert(UdpConnTask::new(
-                            connector,
-                            handle,
-                            abort_handle,
-                            self.dns.clone(),
-                            notify,
-                            IPVersion::from_addr(&local_addr.ip()),
-                        ));
-                        return Ok(());
+        let choose_a_local_port = local_addr.port() == 0;
+
+        for _ in 0..10 {
+            let port = if choose_a_local_port {
+                rand::thread_rng().gen_range(32768..65534)
+            } else {
+                local_addr.port()
+            };
+            return match self.udp_conn.entry(port) {
+                Entry::Occupied(_) => {
+                    if choose_a_local_port {
+                        continue;
                     }
+                    Err(ErrorKind::AddrInUse.into())
                 }
-            }
-            Err(ErrorKind::AddrNotAvailable.into())
-        } else {
-            match self.udp_conn.entry(local_addr.port()) {
-                Entry::Occupied(_) => Err(ErrorKind::AddrInUse.into()),
                 Entry::Vacant(e) => {
                     let handle = Self::open_udp_inner(
                         &mut self.socket_set,
@@ -604,8 +580,9 @@ impl SmolStack {
                     ));
                     Ok(())
                 }
-            }
+            };
         }
+        Err(ErrorKind::AddrNotAvailable.into())
     }
 
     fn open_udp_inner(
@@ -860,7 +837,7 @@ impl RuntimeProvider for SmolDnsProvider {
     fn connect_tcp(
         &self,
         server_addr: SocketAddr,
-    ) -> Pin<Box<dyn Send + Future<Output = std::io::Result<Self::Tcp>>>> {
+    ) -> Pin<Box<dyn Send + Future<Output = io::Result<Self::Tcp>>>> {
         let smol = self.smol.upgrade();
         let handle = self.abort_handle.clone();
         let notify = self.notify.clone();
@@ -889,7 +866,7 @@ impl RuntimeProvider for SmolDnsProvider {
         &self,
         local_addr: SocketAddr,
         _server_addr: SocketAddr,
-    ) -> Pin<Box<dyn Send + Future<Output = std::io::Result<Self::Udp>>>> {
+    ) -> Pin<Box<dyn Send + Future<Output = io::Result<Self::Udp>>>> {
         let smol = self.smol.upgrade();
         let notify = self.notify.clone();
         let handle = self.abort_handle.clone();

--- a/boltconn/src/transport/smol.rs
+++ b/boltconn/src/transport/smol.rs
@@ -298,7 +298,7 @@ impl UdpConnTask {
                             None
                         }
                     }
-                    NetworkAddr::DomainName { domain_name, port } => dns
+                    NetworkAddr::DomainName { domain_name, port } => match dns
                         .genuine_lookup_with(
                             domain_name.as_str(),
                             match socket_version {
@@ -307,7 +307,11 @@ impl UdpConnTask {
                             },
                         )
                         .await
-                        .map(|ip| SocketAddr::new(ip, port)),
+                    {
+                        Ok(Some(ip)) => Some(SocketAddr::new(ip, port)),
+                        Ok(None) => None,
+                        Err(_) => return,
+                    },
                 } {
                     if tx.send_async((buf, dst)).await.is_err() {
                         return;

--- a/boltconn/src/transport/smol.rs
+++ b/boltconn/src/transport/smol.rs
@@ -700,6 +700,12 @@ impl SmolStack {
             }
         });
     }
+
+    /// Terminate all connections with fatal errors
+    pub fn terminate_all(&mut self) {
+        self.tcp_conn.clear();
+        self.udp_conn.clear();
+    }
 }
 
 // -----------------------------------------------------------------------------------

--- a/boltconn/src/transport/smol.rs
+++ b/boltconn/src/transport/smol.rs
@@ -384,6 +384,7 @@ impl Drop for UdpConnTask {
 //          Program -- TCP/UDP -> SmolStack -> IP -- Internet
 //                   \ TCP/UDP <- SmolStack <- IP /
 pub struct SmolStack {
+    name: String,
     tcp_conn: DashMap<u16, TcpConnTask>,
     udp_conn: DashMap<u16, UdpConnTask>,
     ip_addr: InterfaceAddress,
@@ -396,6 +397,7 @@ pub struct SmolStack {
 
 impl SmolStack {
     pub fn new(
+        name: &str,
         iface_ip: InterfaceAddress,
         mut ip_device: VirtualIpDevice,
         dns: Arc<GenericDns<SmolDnsProvider>>,
@@ -416,6 +418,7 @@ impl SmolStack {
             }
         });
         Self {
+            name: name.to_string(),
             tcp_conn: Default::default(),
             udp_conn: Default::default(),
             ip_addr: iface_ip,

--- a/boltconn/src/transport/wireguard.rs
+++ b/boltconn/src/transport/wireguard.rs
@@ -109,7 +109,7 @@ impl WireguardTunnel {
             } => {
                 let resp = dns
                     .genuine_lookup(domain_name)
-                    .await
+                    .await?
                     .ok_or_else(|| io_err("dns not found"))?;
                 SocketAddr::new(resp, port)
             }

--- a/boltconn/src/transport/wireguard.rs
+++ b/boltconn/src/transport/wireguard.rs
@@ -125,7 +125,8 @@ impl WireguardTunnel {
         let buf_pool = Arc::new({
             let pool = Pool::<Vec<u8>>::new();
             // allocate memory in advance
-            const INIT_POOL_SIZE: usize = 4096;
+            // TODO: profile to determine removal
+            const INIT_POOL_SIZE: usize = 128;
             let mut index_arr = [0; INIT_POOL_SIZE];
             for entry in index_arr.iter_mut() {
                 *entry = pool

--- a/boltconn/src/transport/wireguard.rs
+++ b/boltconn/src/transport/wireguard.rs
@@ -316,6 +316,11 @@ impl WireguardTunnel {
             }
         }
     }
+
+    pub async fn stats(&self) -> (bool, Option<std::time::Duration>) {
+        let tun = self.tunnel.lock().await;
+        (tun.is_expired(), tun.stats().0)
+    }
 }
 
 impl WireguardTunnelInner {

--- a/boltconn/src/transport/wireguard.rs
+++ b/boltconn/src/transport/wireguard.rs
@@ -41,6 +41,7 @@ pub struct WireguardConfig {
 impl Debug for WireguardConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("")
+            .field(&self.name)
             .field(&self.ip_addr)
             .field(&self.ip_addr6)
             .field(&self.endpoint)
@@ -51,7 +52,8 @@ impl Debug for WireguardConfig {
 
 impl PartialEq for WireguardConfig {
     fn eq(&self, other: &Self) -> bool {
-        self.public_key == other.public_key
+        self.name == other.name
+            && self.public_key == other.public_key
             && self.ip_addr == other.ip_addr
             && self.ip_addr6 == other.ip_addr6
             && self.endpoint == other.endpoint
@@ -62,6 +64,7 @@ impl Eq for WireguardConfig {}
 
 impl Hash for WireguardConfig {
     fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
         self.ip_addr.hash(state);
         self.ip_addr6.hash(state);
         self.public_key.hash(state);


### PR DESCRIPTION
This PR is an aggregated patch for WireGuard:
- fix hugh memory footprint issue introduced by the previous performance patch where default WireGuard receiver buffer pool is too large by default
- fix the dropped error in internal channel resulting in failed WireGuard reconnection after switching networks

Some other changes:
- data path errors now show with the name of the corresponding proxies
- internal debug info for wireguard master connections (disabled by default)