### PR TITLE
feat: add rootless mode for non-privileged environment

### DIFF
--- a/boltconn/src/cli/mod.rs
+++ b/boltconn/src/cli/mod.rs
@@ -134,8 +134,12 @@ pub(crate) struct StartOptions {
     /// Path of certificate. Default to ${app_data}/cert
     #[arg(long)]
     pub cert: Option<PathBuf>,
+    /// Whether to enable TUN interface at startup. Default to true.
     #[arg(short = 't', long = "tun")]
     pub enable_tun: Option<bool>,
+    /// Run in rootless mode. Certain features may not be available in this mode.
+    #[arg(long)]
+    pub rootless: bool,
 }
 
 #[derive(Debug, Args)]

--- a/boltconn/src/main.rs
+++ b/boltconn/src/main.rs
@@ -60,8 +60,8 @@ fn main() -> ExitCode {
         SubCommand::Start(sub) => sub,
         _ => rt.block_on(cli::controller_main(args)),
     };
-    if !is_root() {
-        eprintln!("BoltConn must be run with root privilege");
+    if !is_root() && !cmds.rootless {
+        eprintln!("BoltConn must be run with root privilege or under rootless mode. See `boltconn start --help` for more information.");
         return ExitCode::FAILURE;
     }
     let target_fd_size = 7568;
@@ -94,6 +94,7 @@ fn main() -> ExitCode {
         data_path,
         cert_path,
         cmds.enable_tun,
+        cmds.rootless,
     )) {
         Ok(app) => app,
         Err(e) => {

--- a/boltconn/src/main.rs
+++ b/boltconn/src/main.rs
@@ -120,21 +120,21 @@ pub(crate) fn process_path(cmds: &StartOptions) -> Result<(PathBuf, PathBuf, Pat
     // test if the paths exist
     if !config_path.try_exists().is_ok_and(|x| x) {
         eprintln!(
-            "Config path {} not found.\nDo you forget to run `boltconn init` first?",
+            "Config path {} not found.\nDo you forget to run `boltconn generate` first?",
             config_path.to_string_lossy()
         );
         return Err(ExitCode::FAILURE);
     }
     if !data_path.try_exists().is_ok_and(|x| x) {
         eprintln!(
-            "Data path {} not found.\nDo you forget to run `boltconn init` first?",
+            "Data path {} not found.\nDo you forget to run `boltconn generate` first?",
             data_path.to_string_lossy()
         );
         return Err(ExitCode::FAILURE);
     }
     if !cert_path.try_exists().is_ok_and(|x| x) {
         eprintln!(
-            "Certificate path {} not found.\nDo you forget to run `sudo boltconn init` first?",
+            "Certificate path {} not found.\nDo you forget to run `boltconn generate` first?",
             cert_path.to_string_lossy()
         );
         return Err(ExitCode::FAILURE);

--- a/boltconn/src/network/configure.rs
+++ b/boltconn/src/network/configure.rs
@@ -20,6 +20,7 @@ macro_rules! check_rootless {
             tracing::warn!(
                 "TUN mode is disabled in rootless mode; no configuration will be applied"
             );
+            #[allow(clippy::unused_unit)]
             return $ret;
         }
     };

--- a/boltconn/src/network/configure.rs
+++ b/boltconn/src/network/configure.rs
@@ -11,20 +11,34 @@ pub struct TunConfigure {
     outbound_name: String,
     dns_handle: Option<SystemDnsHandle>,
     routing_table_flag: bool,
+    rootless: bool,
+}
+
+macro_rules! check_rootless {
+    ($self:ident, $ret:expr) => {
+        if $self.rootless {
+            tracing::warn!(
+                "TUN mode is disabled in rootless mode; no configuration will be applied"
+            );
+            return $ret;
+        }
+    };
 }
 
 impl TunConfigure {
-    pub fn new(dns_addr: Ipv4Addr, device_name: &str, outbound_name: &str) -> Self {
+    pub fn new(dns_addr: Ipv4Addr, device_name: &str, outbound_name: &str, rootless: bool) -> Self {
         Self {
             dns_addr,
             device_name: device_name.to_string(),
             outbound_name: outbound_name.to_string(),
             dns_handle: None,
             routing_table_flag: false,
+            rootless,
         }
     }
 
     pub fn enable(&mut self) -> io::Result<()> {
+        check_rootless!(self, Ok(()));
         self.enable_dns()?;
         if let Err(e) = self.enable_routing_table() {
             self.disable_dns();
@@ -35,6 +49,14 @@ impl TunConfigure {
     }
 
     pub fn disable(&mut self, show_log: bool) {
+        if self.rootless {
+            if show_log {
+                tracing::warn!(
+                    "TUN mode is disabled in rootless mode; no configuration will be applied"
+                );
+            }
+            return;
+        }
         self.disable_routing_table();
         self.disable_dns();
         if show_log {
@@ -47,6 +69,7 @@ impl TunConfigure {
     }
 
     fn enable_dns(&mut self) -> io::Result<()> {
+        check_rootless!(self, Ok(()));
         if self.dns_handle.is_none() {
             self.dns_handle = Some(SystemDnsHandle::new(
                 self.dns_addr,
@@ -58,6 +81,7 @@ impl TunConfigure {
     }
 
     fn enable_routing_table(&mut self) -> io::Result<()> {
+        check_rootless!(self, Ok(()));
         if !self.routing_table_flag {
             setup_ipv4_routing_table(self.device_name.as_str())?;
             self.routing_table_flag = true;
@@ -66,10 +90,12 @@ impl TunConfigure {
     }
 
     fn disable_dns(&mut self) {
+        check_rootless!(self, ());
         self.dns_handle = None
     }
 
     fn disable_routing_table(&mut self) {
+        check_rootless!(self, ());
         if self.routing_table_flag {
             for item in ipv4_relay_addresses() {
                 let _ = platform::delete_route_entry(IpNet::V4(item));


### PR DESCRIPTION
This PR is intended to enable BoltConn running without root permissions. 

Certain features will be unavailable under rootless mode:
- TUN mode
- Auto routing table configuration
- Process detection will be less effective (for privileged processes)